### PR TITLE
Fix gdiplus.dll cannot find issue

### DIFF
--- a/Essentials/gdiplus.yml
+++ b/Essentials/gdiplus.yml
@@ -19,12 +19,12 @@ Steps:
   
 - action: copy_cab_dll
   file_name: gdiplus.dll
-  url: temp/windows6.1-kb976932-x86/x86_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_72d18a4386696c80
+  url: temp/windows6_1-kb976932-x86/x86_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_72d18a4386696c80
   dest: windows/system32/gdiplus.dll
   
 - action: copy_cab_dll
   file_name: gdiplus.dll
-  url: temp/windows6.1-kb976932-x64/amd64_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_2b24536c71ed437a
+  url: temp/windows6_1-kb976932-x64/amd64_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_2b24536c71ed437a
   dest: windows/syswow64/gdiplus.dll
   
 - action: override_dll


### PR DESCRIPTION
`dll gdiplus.dll not found in temp, there should be other errors from cabextract.`

Changes: temp/windows6.1 -> temp/windows6_1

While cabextract performed. the directories created named as `windows6_1`. not a `windows6.1`.

---

P.S. This program is fascinating! I haven't used programs much like this before. I'll add Korean translation if time allows!