### PR TITLE
adapt manifests to new dependency manager

### DIFF
--- a/Essentials/atmlib.yml
+++ b/Essentials/atmlib.yml
@@ -5,13 +5,18 @@ License: Adobe
 License_url: https://www.adobe.com/products/atmlight.html
 Dependencies: []
 Steps:
-- action: cab_extract
+- action: download_archive
   file_name: W2KSP4_EN.EXE
   url: http://x3270.bgp.nu/download/specials/W2KSP4_EN.EXE
   rename: w2ksp4_en.exe
   file_checksum: a4ef6c91d418418b287cefe31f958175
   
-- action: copy_cab_dll
+- action: get_from_cab
+  source: w2ksp4_en.exe
   file_name: atmlib.dl_
-  url: temp/w2ksp4_en/i386
-  dest: windows/system32/atmlib.dll
+  dest: temp/atmlib/
+  
+- action: get_from_cab
+  source: atmlib/i386/atmlib.dl_
+  file_name: atmlib.dll
+  dest: windows/system32/

--- a/Essentials/atmlib.yml
+++ b/Essentials/atmlib.yml
@@ -19,4 +19,4 @@ Steps:
 - action: get_from_cab
   source: atmlib/i386/atmlib.dl_
   file_name: atmlib.dll
-  dest: windows/system32/
+  dest: win32

--- a/Essentials/d3dcompiler_43.yml
+++ b/Essentials/d3dcompiler_43.yml
@@ -5,31 +5,33 @@ License: Microsoft EULA
 License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
 Dependencies: []
 Steps:
-- action: cab_extract
+- action: download_archive
   file_name: directx_Jun2010_redist.exe
   url: https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe
   # urlAlt: http://web.archive.org/web/20210513223919/https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe
   file_checksum: 822e4c516600e81dc7fb16d9a77ec6d4
   
-- action: cab_extract
+- action: get_from_cab
+  source: directx_Jun2010_redist.exe
   file_name: Jun2010_D3DCompiler_43_x86.cab
-  rename: d3dcompiler_43_x86
-  url: temp/directx_Jun2010_redist
+  dest: temp/d3dcompiler_43_x86/
   
-- action: cab_extract
+- action: get_from_cab
+  source: directx_Jun2010_redist.exe
   file_name: Jun2010_D3DCompiler_43_x64.cab
-  rename: d3dcompiler_43_x64
-  url: temp/directx_Jun2010_redist
+  dest: temp/d3dcompiler_43_x64/
 
-- action: copy_cab_dll
+- action: get_from_cab
+  source: d3dcompiler_43_x86/Jun2010_D3DCompiler_43_x86.cab
   file_name: D3DCompiler_43.dll
-  url: temp/d3dcompiler_43_x86
-  dest: windows/system32/d3dcompiler_43.dll
+  dest: windows/system32/
+  rename: d3dcompiler_43.dll
 
-- action: copy_cab_dll
+- action: get_from_cab
+  source: d3dcompiler_43_x64/Jun2010_D3DCompiler_43_x64.cab
   file_name: D3DCompiler_43.dll
-  url: temp/d3dcompiler_43_x64
-  dest: windows/syswow64/d3dcompiler_43.dll
+  dest: windows/syswow64/
+  rename: d3dcompiler_43.dll
   
 - action: override_dll
   dll: d3dcompiler_43

--- a/Essentials/d3dcompiler_43.yml
+++ b/Essentials/d3dcompiler_43.yml
@@ -24,13 +24,13 @@ Steps:
 - action: get_from_cab
   source: d3dcompiler_43_x86/Jun2010_D3DCompiler_43_x86.cab
   file_name: D3DCompiler_43.dll
-  dest: windows/system32/
+  dest: win32
   rename: d3dcompiler_43.dll
 
 - action: get_from_cab
   source: d3dcompiler_43_x64/Jun2010_D3DCompiler_43_x64.cab
   file_name: D3DCompiler_43.dll
-  dest: windows/syswow64/
+  dest: win64/
   rename: d3dcompiler_43.dll
   
 - action: override_dll

--- a/Essentials/d3dcompiler_46.yml
+++ b/Essentials/d3dcompiler_46.yml
@@ -18,13 +18,13 @@ Steps:
 - action: get_from_cab
   source: 2630bae9681db6a9f6722366f47d055c.cab
   file_name: fil47ed91e900f4b9d9659b66a211b57c39
-  dest: windows/system32/
+  dest: win32
   rename: d3dcompiler_46.dll
   
 - action: get_from_cab
   source: 61d57a7a82309cd161a854a6f4619e52.cab
   file_name: fil8c20206095817436f8df4a711faee5b7
-  dest: windows/syswow64/
+  dest: win64/
   rename: d3dcompiler_46.dll
   
 - action: override_dll

--- a/Essentials/d3dcompiler_46.yml
+++ b/Essentials/d3dcompiler_46.yml
@@ -5,25 +5,27 @@ License: Microsoft EULA
 License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
 Dependencies: []
 Steps:
-- action: cab_extract
+- action: download_archive
   file_name: 2630bae9681db6a9f6722366f47d055c.cab
   url: http://download.microsoft.com/download/F/1/3/F1300C9C-A120-4341-90DF-8A52509B23AC/standalonesdk/Installers/2630bae9681db6a9f6722366f47d055c.cab
   file_checksum: 9cc65b7e3aeebed781354b3a5399ece0
   
-- action: cab_extract
+- action: download_archive
   file_name: 61d57a7a82309cd161a854a6f4619e52.cab
   url: http://download.microsoft.com/download/F/1/3/F1300C9C-A120-4341-90DF-8A52509B23AC/standalonesdk/Installers/61d57a7a82309cd161a854a6f4619e52.cab
   file_checksum: 9b92033822629a13ea60d5b4459faa5c
   
-- action: copy_cab_dll
+- action: get_from_cab
+  source: 2630bae9681db6a9f6722366f47d055c.cab
   file_name: fil47ed91e900f4b9d9659b66a211b57c39
-  url: temp/2630bae9681db6a9f6722366f47d055c
-  dest: windows/system32/d3dcompiler_46.dll
+  dest: windows/system32/
+  rename: d3dcompiler_46.dll
   
-- action: copy_cab_dll
+- action: get_from_cab
+  source: 61d57a7a82309cd161a854a6f4619e52.cab
   file_name: fil8c20206095817436f8df4a711faee5b7
-  url: temp/61d57a7a82309cd161a854a6f4619e52
-  dest: windows/syswow64/d3dcompiler_46.dll
+  dest: windows/syswow64/
+  rename: d3dcompiler_46.dll
   
 - action: override_dll
   dll: d3dcompiler_46

--- a/Essentials/d3dcompiler_47.yml
+++ b/Essentials/d3dcompiler_47.yml
@@ -17,12 +17,12 @@ Steps:
   file_checksum: 58aabc1588593297851c38c6edf8736f
   rename: firefox_setup_6203_64bit.7z
   
-- action: copy_cab_dll
+- action: copy_dll
   file_name: core/d3dcompiler_47.dll
   url: temp/firefox_setup_6203_32bit
   dest: windows/system32/d3dcompiler_47.dll
   
-- action: copy_cab_dll
+- action: copy_dll
   file_name: core/d3dcompiler_47.dll
   url: temp/firefox_setup_6203_64bit
   dest: windows/syswow64/d3dcompiler_47.dll

--- a/Essentials/d3dcompiler_47.yml
+++ b/Essentials/d3dcompiler_47.yml
@@ -20,7 +20,7 @@ Steps:
 - action: copy_dll
   file_name: core/d3dcompiler_47.dll
   url: temp/firefox_setup_6203_32bit
-  dest: win32d3dcompiler_47.dll
+  dest: win32/d3dcompiler_47.dll
   
 - action: copy_dll
   file_name: core/d3dcompiler_47.dll

--- a/Essentials/d3dcompiler_47.yml
+++ b/Essentials/d3dcompiler_47.yml
@@ -20,12 +20,12 @@ Steps:
 - action: copy_dll
   file_name: core/d3dcompiler_47.dll
   url: temp/firefox_setup_6203_32bit
-  dest: windows/system32/d3dcompiler_47.dll
+  dest: win32d3dcompiler_47.dll
   
 - action: copy_dll
   file_name: core/d3dcompiler_47.dll
   url: temp/firefox_setup_6203_64bit
-  dest: windows/syswow64/d3dcompiler_47.dll
+  dest: win64/d3dcompiler_47.dll
   
 - action: override_dll
   dll: d3dcompiler_47

--- a/Essentials/d3dx9.yml
+++ b/Essentials/d3dx9.yml
@@ -17,203 +17,203 @@ Steps:
 - action: get_from_cab
   source: directx_Jun2010_redist/Apr2005_d3dx9_25_x86.cab
   file_name: d3dx9_25
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Apr2006_d3dx9_30_x86.cab
   file_name: d3dx9_30
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/APR2007_d3dx9_33_x86.cab
   file_name: d3dx9_33
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Aug2005_d3dx9_27_x86.cab
   file_name: d3dx9_27
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/AUG2007_d3dx9_35_x86.cab
   file_name: d3dx9_35
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Aug2008_d3dx9_39_x86.cab
   file_name: d3dx9_39
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Aug2009_d3dx9_42_x86.cab
   file_name: d3dx9_42
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Dec2005_d3dx9_28_x86.cab
   file_name: d3dx9_28
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/DEC2006_d3dx9_32_x86.cab
   file_name: d3dx9_32
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Feb2005_d3dx9_24_x86.cab
   file_name: d3dx9_24
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Feb2006_d3dx9_29_x86.cab
   file_name: d3dx9_29
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Jun2005_d3dx9_26_x86.cab
   file_name: d3dx9_26
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/JUN2007_d3dx9_34_x86.cab
   file_name: d3dx9_34
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/JUN2008_d3dx9_38_x86.cab
   file_name: d3dx9_38
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Jun2010_d3dx9_43_x86.cab
   file_name: d3dx9_43
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Mar2008_d3dx9_37_x86.cab
   file_name: d3dx9_37
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Mar2009_d3dx9_41_x86.cab
   file_name: d3dx9_41
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Nov2007_d3dx9_36_x86.cab
   file_name: d3dx9_36
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Nov2008_d3dx9_40_x86.cab
   file_name: d3dx9_40
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: directx_Jun2010_redist/OCT2006_d3dx9_31_x86.cab
   file_name: d3dx9_31
-  dest: windows/system32/
+  dest: win32
 
 # x64 dlls
 - action: get_from_cab
   source: directx_Jun2010_redist/Apr2005_d3dx9_25_x64.cab
   file_name: d3dx9_25
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Apr2006_d3dx9_30_x64.cab
   file_name: d3dx9_30
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/APR2007_d3dx9_33_x64.cab
   file_name: d3dx9_33
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Aug2005_d3dx9_27_x64.cab
   file_name: d3dx9_27
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/AUG2007_d3dx9_35_x64.cab
   file_name: d3dx9_35
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Aug2008_d3dx9_39_x64.cab
   file_name: d3dx9_39
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Aug2009_d3dx9_42_x64.cab
   file_name: d3dx9_42
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Dec2005_d3dx9_28_x64.cab
   file_name: d3dx9_28
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/DEC2006_d3dx9_32_x64.cab
   file_name: d3dx9_32
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Feb2005_d3dx9_24_x64.cab
   file_name: d3dx9_24
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Feb2006_d3dx9_29_x64.cab
   file_name: d3dx9_29
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Jun2005_d3dx9_26_x64.cab
   file_name: d3dx9_26
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/JUN2007_d3dx9_34_x64.cab
   file_name: d3dx9_34
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/JUN2008_d3dx9_38_x64.cab
   file_name: d3dx9_38
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Jun2010_d3dx9_43_x64.cab
   file_name: d3dx9_43
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Mar2008_d3dx9_37_x64.cab
   file_name: d3dx9_37
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Mar2009_d3dx9_41_x64.cab
   file_name: d3dx9_41
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Nov2007_d3dx9_36_x64.cab
   file_name: d3dx9_36
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/Nov2008_d3dx9_40_x64.cab
   file_name: d3dx9_40
-  dest: windows/syswow64/
+  dest: win64/
 
 - action: get_from_cab
   source: directx_Jun2010_redist/OCT2006_d3dx9_31_x64.cab
   file_name: d3dx9_31
-  dest: windows/syswow64/
+  dest: win64/
   
 # DLL overrides
 - action: override_dll

--- a/Essentials/d3dx9.yml
+++ b/Essentials/d3dx9.yml
@@ -10,27 +10,211 @@ Steps:
   url: https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe
   # urlAlt: http://web.archive.org/web/20210513223919/https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe
   file_checksum: 822e4c516600e81dc7fb16d9a77ec6d4
+  dest: temp/directx_Jun2010_redist/
 
-- action: cab_extract
-  file_name: "*_d3dx9*x86.cab"
-  rename: "d3dx9_x86"
-  url: temp/directx_Jun2010_redist
 
-- action: cab_extract
-  file_name: "*_d3dx9*x64.cab"
-  rename: "d3dx9_x64"
-  url: temp/directx_Jun2010_redist
+# x86 dlls
+- action: get_from_cab
+  source: directx_Jun2010_redist/Apr2005_d3dx9_25_x86.cab
+  file_name: d3dx9_25
+  dest: windows/system32/
 
-- action: copy_cab_dll
-  file_name: d3dx9_*.dll
-  url: temp/d3dx9_x86
-  dest: windows/system32
+- action: get_from_cab
+  source: directx_Jun2010_redist/Apr2006_d3dx9_30_x86.cab
+  file_name: d3dx9_30
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/APR2007_d3dx9_33_x86.cab
+  file_name: d3dx9_33
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Aug2005_d3dx9_27_x86.cab
+  file_name: d3dx9_27
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/AUG2007_d3dx9_35_x86.cab
+  file_name: d3dx9_35
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Aug2008_d3dx9_39_x86.cab
+  file_name: d3dx9_39
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Aug2009_d3dx9_42_x86.cab
+  file_name: d3dx9_42
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Dec2005_d3dx9_28_x86.cab
+  file_name: d3dx9_28
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/DEC2006_d3dx9_32_x86.cab
+  file_name: d3dx9_32
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Feb2005_d3dx9_24_x86.cab
+  file_name: d3dx9_24
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Feb2006_d3dx9_29_x86.cab
+  file_name: d3dx9_29
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Jun2005_d3dx9_26_x86.cab
+  file_name: d3dx9_26
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/JUN2007_d3dx9_34_x86.cab
+  file_name: d3dx9_34
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/JUN2008_d3dx9_38_x86.cab
+  file_name: d3dx9_38
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Jun2010_d3dx9_43_x86.cab
+  file_name: d3dx9_43
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Mar2008_d3dx9_37_x86.cab
+  file_name: d3dx9_37
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Mar2009_d3dx9_41_x86.cab
+  file_name: d3dx9_41
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Nov2007_d3dx9_36_x86.cab
+  file_name: d3dx9_36
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Nov2008_d3dx9_40_x86.cab
+  file_name: d3dx9_40
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/OCT2006_d3dx9_31_x86.cab
+  file_name: d3dx9_31
+  dest: windows/system32/
+
+# x64 dlls
+- action: get_from_cab
+  source: directx_Jun2010_redist/Apr2005_d3dx9_25_x64.cab
+  file_name: d3dx9_25
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Apr2006_d3dx9_30_x64.cab
+  file_name: d3dx9_30
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/APR2007_d3dx9_33_x64.cab
+  file_name: d3dx9_33
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Aug2005_d3dx9_27_x64.cab
+  file_name: d3dx9_27
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/AUG2007_d3dx9_35_x64.cab
+  file_name: d3dx9_35
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Aug2008_d3dx9_39_x64.cab
+  file_name: d3dx9_39
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Aug2009_d3dx9_42_x64.cab
+  file_name: d3dx9_42
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Dec2005_d3dx9_28_x64.cab
+  file_name: d3dx9_28
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/DEC2006_d3dx9_32_x64.cab
+  file_name: d3dx9_32
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Feb2005_d3dx9_24_x64.cab
+  file_name: d3dx9_24
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Feb2006_d3dx9_29_x64.cab
+  file_name: d3dx9_29
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Jun2005_d3dx9_26_x64.cab
+  file_name: d3dx9_26
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/JUN2007_d3dx9_34_x64.cab
+  file_name: d3dx9_34
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/JUN2008_d3dx9_38_x64.cab
+  file_name: d3dx9_38
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Jun2010_d3dx9_43_x64.cab
+  file_name: d3dx9_43
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Mar2008_d3dx9_37_x64.cab
+  file_name: d3dx9_37
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Mar2009_d3dx9_41_x64.cab
+  file_name: d3dx9_41
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Nov2007_d3dx9_36_x64.cab
+  file_name: d3dx9_36
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/Nov2008_d3dx9_40_x64.cab
+  file_name: d3dx9_40
+  dest: windows/syswow64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist/OCT2006_d3dx9_31_x64.cab
+  file_name: d3dx9_31
+  dest: windows/syswow64/
   
-- action: copy_cab_dll
-  file_name: d3dx9_*.dll
-  url: temp/d3dx9_x64
-  dest: windows/syswow64
-
 # DLL overrides
 - action: override_dll
   dll: d3dx9_24

--- a/Essentials/faudio.yml
+++ b/Essentials/faudio.yml
@@ -14,12 +14,12 @@ Steps:
 - action: copy_dll
   file_name: '*.dll'
   url: temp/faudio_20_07/faudio-20.07/x64
-  dest: windows/system32
+  dest: win32
   
 - action: copy_dll
   file_name: '*.dll'
   url: temp/faudio_20_07/faudio-20.07/x64
-  dest: windows/syswow64
+  dest: win64
   
 - action: override_dll
   dll: '*.dll'

--- a/Essentials/faudio.yml
+++ b/Essentials/faudio.yml
@@ -11,12 +11,12 @@ Steps:
   url: https://github.com/Kron4ek/FAudio-Builds/releases/download/20.07/faudio-20.07.tar.xz
   file_checksum: 7385a4d276f940e025488e74a967789b
   
-- action: copy_cab_dll
+- action: copy_dll
   file_name: '*.dll'
   url: temp/faudio_20_07/faudio-20.07/x64
   dest: windows/system32
   
-- action: copy_cab_dll
+- action: copy_dll
   file_name: '*.dll'
   url: temp/faudio_20_07/faudio-20.07/x64
   dest: windows/syswow64

--- a/Essentials/gdiplus.yml
+++ b/Essentials/gdiplus.yml
@@ -20,12 +20,12 @@ Steps:
 - action: get_from_cab
   source: windows6.1-kb976932-x86.exe
   file_name: gdiplus.dll
-  dest: windows/system32/
+  dest: win32
 
 - action: get_from_cab
   source: windows6.1-kb976932-x64.exe
   file_name: gdiplus.dll
-  dest: windows/syswow64/
+  dest: win64/
   
 - action: override_dll
   dll: gdiplus

--- a/Essentials/gdiplus.yml
+++ b/Essentials/gdiplus.yml
@@ -5,27 +5,27 @@ License: Microsoft EULA
 License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
 Dependencies: []
 Steps:
-- action: cab_extract
+- action: download_archive
   file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
   url:  http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
   rename: windows6.1-kb976932-x86.exe
   file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
 
-- action: cab_extract
+- action: download_archive
   file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
   url:  http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
   rename: windows6.1-kb976932-x64.exe
   file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
-  
-- action: copy_cab_dll
+
+- action: get_from_cab
+  source: windows6.1-kb976932-x86.exe
   file_name: gdiplus.dll
-  url: temp/windows6_1-kb976932-x86/x86_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_72d18a4386696c80
-  dest: windows/system32/gdiplus.dll
-  
-- action: copy_cab_dll
+  dest: windows/system32/
+
+- action: get_from_cab
+  source: windows6.1-kb976932-x64.exe
   file_name: gdiplus.dll
-  url: temp/windows6_1-kb976932-x64/amd64_microsoft.windows.gdiplus_6595b64144ccf1df_1.1.7601.17514_none_2b24536c71ed437a
-  dest: windows/syswow64/gdiplus.dll
+  dest: windows/syswow64/
   
 - action: override_dll
   dll: gdiplus

--- a/Essentials/mediafoundation.yml
+++ b/Essentials/mediafoundation.yml
@@ -20,12 +20,12 @@ Steps:
 - action: get_from_cab
   source: windows6.1-kb976932-x86.exe
   file_name: x86_microsoft-windows-mediafoundation_31bf3856ad364e35_6.1.7601.17514_none_9e6699276b03c38e/mf.dll
-  dest: windows/system32/
+  dest: win32
   
 - action: get_from_cab
   source: windows6.1-kb976932-x64.exe
   file_name: amd64_microsoft-windows-mediafoundation_31bf3856ad364e35_6.1.7601.17514_none_fa8534ab236134c4/mf.dll
-  dest: windows/syswow64/  
+  dest: win64/  
 
 - action: override_dll
   dll: mf

--- a/Essentials/mediafoundation.yml
+++ b/Essentials/mediafoundation.yml
@@ -20,14 +20,12 @@ Steps:
 - action: get_from_cab
   source: windows6.1-kb976932-x86.exe
   file_name: x86_microsoft-windows-mediafoundation_31bf3856ad364e35_6.1.7601.17514_none_9e6699276b03c38e/mf.dll
-  dest: drive_c/windows/system32/
-  rename: mf.dll
+  dest: windows/system32/
   
 - action: get_from_cab
   source: windows6.1-kb976932-x64.exe
   file_name: amd64_microsoft-windows-mediafoundation_31bf3856ad364e35_6.1.7601.17514_none_fa8534ab236134c4/mf.dll
-  dest: drive_c/windows/syswow64/  
-  rename: mf.dll
+  dest: windows/syswow64/  
 
 - action: override_dll
   dll: mf

--- a/Essentials/msls31.yml
+++ b/Essentials/msls31.yml
@@ -5,15 +5,15 @@ License: Microsoft EULA
 License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
 Dependencies: []
 Steps:
-- action: cab_extract
+- action: download_archive
   file_name: nstMsiW.exe
   url: https://web.archive.org/web/20160710055851if_/http://download.microsoft.com/download/WindowsInstaller/Install/2.0/NT45/EN-US/InstMsiW.exe
   file_checksum: 53820efbc952107ee1a38be6cd5aa3f0
   
-- action: copy_cab_dll
+- action: get_from_cab
+  source: nstMsiW.exe
   file_name: msls31.dll
-  url: temp/nstMsiW
-  dest: windows/system32/msls31.dll
+  dest: windows/system32/
 
 - action: override_dll
   dll: msls31

--- a/Essentials/msls31.yml
+++ b/Essentials/msls31.yml
@@ -13,7 +13,7 @@ Steps:
 - action: get_from_cab
   source: nstMsiW.exe
   file_name: msls31.dll
-  dest: windows/system32/
+  dest: win32
 
 - action: override_dll
   dll: msls31

--- a/Essentials/msxml6.yml
+++ b/Essentials/msxml6.yml
@@ -15,29 +15,30 @@ Steps:
 - action: get_from_cab
   source: msxml6-KB973686-enu-amd64.exe
   file_name: msxml6.msi
+  dest: temp/msxml6/
   
 - action: get_from_cab
-  source: msxml6.msi
+  source: msxml6/msxml6.msi
   file_name: msxml6.dll.86F857F6_A743_463D_B2FE_98CB5F727E09
-  dest: drive_c/windows/system32/
+  dest: windows/system32/
   rename: msxml6.dll
 
 - action: get_from_cab
-  source: msxml6.msi
+  source: msxml6/msxml6.msi
   file_name: msxml6r.dll.86F857F6_A743_463D_B2FE_98CB5F727E09
-  dest: drive_c/windows/system32/
+  dest: windows/system32/
   rename: msxml6r.dll
 
 - action: get_from_cab
-  source: msxml6.msi
+  source: msxml6/msxml6.msi
   file_name: msxml6.dll.1ECC0691_D2EB_4A33_9CBF_5487E5CB17DB
-  dest: drive_c/windows/syswow64/
+  dest: windows/syswow64/
   rename: msxml6.dll
 
 - action: get_from_cab
-  source: msxml6.msi
+  source: msxml6/msxml6.msi
   file_name: msxml6r.dll.1ECC0691_D2EB_4A33_9CBF_5487E5CB17DB
-  dest: drive_c/windows/syswow64/
+  dest: windows/syswow64/
   rename: msxml6r.dll
   
 - action: override_dll

--- a/Essentials/msxml6.yml
+++ b/Essentials/msxml6.yml
@@ -20,25 +20,25 @@ Steps:
 - action: get_from_cab
   source: msxml6/msxml6.msi
   file_name: msxml6.dll.86F857F6_A743_463D_B2FE_98CB5F727E09
-  dest: windows/system32/
+  dest: win32
   rename: msxml6.dll
 
 - action: get_from_cab
   source: msxml6/msxml6.msi
   file_name: msxml6r.dll.86F857F6_A743_463D_B2FE_98CB5F727E09
-  dest: windows/system32/
+  dest: win32
   rename: msxml6r.dll
 
 - action: get_from_cab
   source: msxml6/msxml6.msi
   file_name: msxml6.dll.1ECC0691_D2EB_4A33_9CBF_5487E5CB17DB
-  dest: windows/syswow64/
+  dest: win64/
   rename: msxml6.dll
 
 - action: get_from_cab
   source: msxml6/msxml6.msi
   file_name: msxml6r.dll.1ECC0691_D2EB_4A33_9CBF_5487E5CB17DB
-  dest: windows/syswow64/
+  dest: win64/
   rename: msxml6r.dll
   
 - action: override_dll

--- a/Essentials/msxml6_testing.yml
+++ b/Essentials/msxml6_testing.yml
@@ -13,29 +13,30 @@ Steps:
 - action: get_from_cab
   source: msxml6-KB973686-enu-amd64.exe
   file_name: msxml6.msi
+  dest: temp/msxml6/
   
 - action: get_from_cab
-  source: msxml6.msi
+  source: msxml6/msxml6.msi
   file_name: msxml6.dll.86F857F6_A743_463D_B2FE_98CB5F727E09
-  dest: drive_c/windows/system32/
+  dest: windows/system32/
   rename: msxml6.dll
 
 - action: get_from_cab
-  source: msxml6.msi
+  source: msxml6/msxml6.msi
   file_name: msxml6r.dll.86F857F6_A743_463D_B2FE_98CB5F727E09
-  dest: drive_c/windows/system32/
+  dest: windows/system32/
   rename: msxml6r.dll
 
 - action: get_from_cab
-  source: msxml6.msi
+  source: msxml6/msxml6.msi
   file_name: msxml6.dll.1ECC0691_D2EB_4A33_9CBF_5487E5CB17DB
-  dest: drive_c/windows/syswow64/
+  dest: windows/syswow64/
   rename: msxml6.dll
 
 - action: get_from_cab
-  source: msxml6.msi
+  source: msxml6/msxml6.msi
   file_name: msxml6r.dll.1ECC0691_D2EB_4A33_9CBF_5487E5CB17DB
-  dest: drive_c/windows/syswow64/
+  dest: windows/syswow64/
   rename: msxml6r.dll
   
 - action: override_dll

--- a/Essentials/msxml6_testing.yml
+++ b/Essentials/msxml6_testing.yml
@@ -18,25 +18,25 @@ Steps:
 - action: get_from_cab
   source: msxml6/msxml6.msi
   file_name: msxml6.dll.86F857F6_A743_463D_B2FE_98CB5F727E09
-  dest: windows/system32/
+  dest: win32
   rename: msxml6.dll
 
 - action: get_from_cab
   source: msxml6/msxml6.msi
   file_name: msxml6r.dll.86F857F6_A743_463D_B2FE_98CB5F727E09
-  dest: windows/system32/
+  dest: win32
   rename: msxml6r.dll
 
 - action: get_from_cab
   source: msxml6/msxml6.msi
   file_name: msxml6.dll.1ECC0691_D2EB_4A33_9CBF_5487E5CB17DB
-  dest: windows/syswow64/
+  dest: win64/
   rename: msxml6.dll
 
 - action: get_from_cab
   source: msxml6/msxml6.msi
   file_name: msxml6r.dll.1ECC0691_D2EB_4A33_9CBF_5487E5CB17DB
-  dest: windows/syswow64/
+  dest: win64/
   rename: msxml6r.dll
   
 - action: override_dll

--- a/Essentials/riched20.yml
+++ b/Essentials/riched20.yml
@@ -19,7 +19,7 @@ Steps:
 - action: get_from_cab
   source: riched20/i386/riched20.dl_
   file_name: riched20.dll
-  dest: windows/system32/
+  dest: win32
 
 - action: override_dll
   dll: riched20

--- a/Essentials/riched20.yml
+++ b/Essentials/riched20.yml
@@ -5,16 +5,21 @@ License: Microsoft EULA
 License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
 Dependencies: []
 Steps:
-- action: cab_extract
+- action: download_archive
   file_name: W2KSP4_EN.EXE
   url: http://x3270.bgp.nu/download/specials/W2KSP4_EN.EXE
   rename: w2ksp4_en.exe
   file_checksum: a4ef6c91d418418b287cefe31f958175
-  
-- action: copy_cab_dll
+
+- action: get_from_cab
+  source: w2ksp4_en.exe
   file_name: riched20.dl_
-  url: temp/w2ksp4_en/i386
-  dest: windows/system32/riched20.dll
+  dest: temp/riched20/
+
+- action: get_from_cab
+  source: riched20/i386/riched20.dl_
+  file_name: riched20.dll
+  dest: windows/system32/
 
 - action: override_dll
   dll: riched20

--- a/Essentials/vcredist6.yml
+++ b/Essentials/vcredist6.yml
@@ -19,57 +19,57 @@ Steps:
 - action: get_from_cab
   file_name: asycfilt.dll
   source: vcredist6/vcredist.exe
-  dest: windows/system32
+  dest: win32
 
 - action: get_from_cab
   file_name: comcat.dll
   source: vcredist6/vcredist.exe
-  dest: windows/system32
+  dest: win32
 
 - action: get_from_cab
   file_name: mfc42.dll
   source: vcredist6/vcredist.exe
-  dest: windows/system32
+  dest: win32
 
 - action: get_from_cab
   file_name: mfc42u.dll
   source: vcredist6/vcredist.exe
-  dest: windows/system32
+  dest: win32
 
 - action: get_from_cab
   file_name: msvcirt.dll
   source: vcredist6/vcredist.exe
-  dest: windows/system32
+  dest: win32
 
 - action: get_from_cab
   file_name: msvcp60.dll
   source: vcredist6/vcredist.exe
-  dest: windows/system32
+  dest: win32
 
 - action: get_from_cab
   file_name: msvcrt.dll
   source: vcredist6/vcredist.exe
-  dest: windows/system32
+  dest: win32
 
 - action: get_from_cab
   file_name: oleaut32.dll
   source: vcredist6/vcredist.exe
-  dest: windows/system32
+  dest: win32
 
 - action: get_from_cab
   file_name: olepro32.dll
   source: vcredist6/vcredist.exe
-  dest: windows/system32
+  dest: win32
 
 - action: get_from_cab
   file_name: atla.dll
   source: vcredist6/vcredist.exe
-  dest: windows/system32
+  dest: win32
 
 - action: get_from_cab
   file_name: stdole2.tlb
   source: vcredist6/vcredist.exe
-  dest: windows/system32
+  dest: win32
 
 - action: override_dll
   dll: asycfilt

--- a/Essentials/vcredist6.yml
+++ b/Essentials/vcredist6.yml
@@ -6,65 +6,70 @@ License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
 Dependencies: []
 Steps:  
 
-- action: cab_extract
+- action: download_archive
   file_name: VC6RedistSetup_deu.exe
   url: https://download.microsoft.com/download/vc60pro/Update/2/W9XNT4/EN-US/VC6RedistSetup_deu.exe
   file_checksum: 53a0925609b366daa17051e1e4be3b86
 
 - action: get_from_cab
+  source: VC6RedistSetup_deu.exe
+  file_name: vcredist.exe
+  dest: temp/vcredist6/
+
+- action: get_from_cab
   file_name: asycfilt.dll
-  source: VC6RedistSetup_deu_exe/vcredist.exe
-  dest: drive_c/windows/system32
+  source: vcredist6/vcredist.exe
+  dest: windows/system32
 
 - action: get_from_cab
   file_name: comcat.dll
-  source: VC6RedistSetup_deu_exe/vcredist.exe
-  dest: drive_c/windows/system32
+  source: vcredist6/vcredist.exe
+  dest: windows/system32
 
 - action: get_from_cab
   file_name: mfc42.dll
-  source: VC6RedistSetup_deu_exe/vcredist.exe
-  dest: drive_c/windows/system32
+  source: vcredist6/vcredist.exe
+  dest: windows/system32
 
 - action: get_from_cab
   file_name: mfc42u.dll
-  source: VC6RedistSetup_deu_exe/vcredist.exe
-  dest: drive_c/windows/system32
+  source: vcredist6/vcredist.exe
+  dest: windows/system32
 
 - action: get_from_cab
   file_name: msvcirt.dll
-  source: VC6RedistSetup_deu_exe/vcredist.exe
-  dest: drive_c/windows/system32
+  source: vcredist6/vcredist.exe
+  dest: windows/system32
 
 - action: get_from_cab
   file_name: msvcp60.dll
-  source: VC6RedistSetup_deu_exe/vcredist.exe
-  dest: drive_c/windows/system32
+  source: vcredist6/vcredist.exe
+  dest: windows/system32
 
 - action: get_from_cab
   file_name: msvcrt.dll
-  source: VC6RedistSetup_deu_exe/vcredist.exe
-  dest: drive_c/windows/system32
+  source: vcredist6/vcredist.exe
+  dest: windows/system32
 
 - action: get_from_cab
   file_name: oleaut32.dll
-  source: VC6RedistSetup_deu_exe/vcredist.exe
-  dest: drive_c/windows/system32
+  source: vcredist6/vcredist.exe
+  dest: windows/system32
 
 - action: get_from_cab
   file_name: olepro32.dll
-  source: VC6RedistSetup_deu_exe/vcredist.exe
-  dest: drive_c/windows/system32
+  source: vcredist6/vcredist.exe
+  dest: windows/system32
 
 - action: get_from_cab
   file_name: atla.dll
-  source: VC6RedistSetup_deu_exe/vcredist.exe
-  dest: drive_c/windows/system32
+  source: vcredist6/vcredist.exe
+  dest: windows/system32
 
 - action: get_from_cab
   file_name: stdole2.tlb
-  source: VC6RedistSetup_deu_exe/vcredist.exe
-  dest: drive_c/windows/system32
+  source: vcredist6/vcredist.exe
+  dest: windows/system32
 
 - action: override_dll
   dll: asycfilt

--- a/Essentials/vcredist6sp6.yml
+++ b/Essentials/vcredist6sp6.yml
@@ -6,14 +6,20 @@ License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
 Dependencies: []
 Steps:  
 
-- action: cab_extract
+- action: download_archive
   file_name: VS6SP6.EXE
   url: https://www.ddsystem.com.br/update/setup/vb6+sp6/VS6SP6.EXE
   file_checksum: b69f34e54fe4603f8d42021891743651
 
-- action: install_exe
+- action: get_from_cab
+  source: VS6SP6.EXE
   file_name: vcredist.exe
-  url: temp/VS6SP6/vcredist.exe
+  dest: temp/vcredist6sp6/
+  rename: vcredist6sp6.exe
+
+- action: install_exe
+  file_name: vcredist6sp6.exe
+  url: temp/vcredist6sp6/vcredist6sp6.exe
   arguments: /q
 
 - action: override_dll

--- a/Fonts/allfonts.yml
+++ b/Fonts/allfonts.yml
@@ -11,56 +11,67 @@ Steps:
   file_name: arial32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/arial32.exe
   file_checksum: 9637df0e91703179f0723ec095a36cb5
+  dest: temp/arial32
   
 - action: cab_extract
   file_name: arialb32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/arialb32.exe
   file_checksum: c9089ae0c3b3d0d8c4b0a95979bb9ff0
+  dest: temp/arialb32
   
 - action: cab_extract
   file_name: andale32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/andale32.exe
   file_checksum: cbdc2fdd7d2ed0832795e86a8b9ee19a
+  dest: temp/andale32
   
 - action: cab_extract
   file_name: comic32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/comic32.exe
   file_checksum: 2b30de40bb5e803a0452c7715fc835d1
+  dest: temp/comic32
   
 - action: cab_extract
   file_name: courie32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/courie32.exe
   file_checksum: 4e412c772294403ab62fb2d247d85c60
+  dest: temp/courie32
   
 - action: cab_extract
   file_name: georgi32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/georgi32.exe
   file_checksum: 4d90016026e2da447593b41a8d8fa8bd
+  dest: temp/georgi32
   
 - action: cab_extract
   file_name: impact32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/impact32.exe
   file_checksum: 7907c7dd6684e9bade91cff82683d9d7
+  dest: temp/impact32
   
 - action: cab_extract
   file_name: times32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/times32.exe
   file_checksum: ed39c8ef91b9fb80f76f702568291bd5
+  dest: temp/times32
   
 - action: cab_extract
   file_name: trebuc32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/trebuc32.exe
   file_checksum: 0d7ea16cac6261f8513a061fbfcdb2b5
+  dest: temp/trebuc32
   
 - action: cab_extract
   file_name: verdan32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/verdan32.exe
   file_checksum: 12d2a75f8156e10607be1eaa8e8ef120
+  dest: temp/verdan32
   
 - action: cab_extract
   file_name: webdin32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/webdin32.exe
   file_checksum: 230a1d13a365b22815f502eb24d9149b
+  dest: temp/webdin32
   
 # following should be included in allfonts or pptfonts
 # calibri
@@ -73,7 +84,7 @@ Steps:
 
 # Install fonts from cab files
 - action: install_cab_fonts
-  url: temp/arial32_exe
+  url: temp/arial32
   fonts: 
    - Ariali.TTF
    - Arialbd.TTF
@@ -81,23 +92,23 @@ Steps:
    - Arial.TTF
   
 - action: install_cab_fonts
-  url: temp/arialb32_exe
+  url: temp/arialb32
   fonts: 
    - AriBlk.TTF
   
 - action: install_cab_fonts
-  url: temp/andale32_exe
+  url: temp/andale32
   fonts: 
    - AndaleMo.TTF
   
 - action: install_cab_fonts
-  url: temp/comic32_exe
+  url: temp/comic32
   fonts: 
    - Comicbd.TTF
    - Comic.TTF
   
 - action: install_cab_fonts
-  url: temp/courie32_exe
+  url: temp/courie32
   fonts: 
    - cour.ttf
    - courbd.ttf
@@ -105,7 +116,7 @@ Steps:
    - couri.ttf
   
 - action: install_cab_fonts
-  url: temp/georgi32_exe
+  url: temp/georgi32
   fonts: 
    - Georgiaz.TTF
    - Georgiab.TTF
@@ -113,12 +124,12 @@ Steps:
    - Georgia.TTF
     
 - action: install_cab_fonts
-  url: temp/impact32_exe
+  url: temp/impact32
   fonts: 
    - Impact.TTF
   
 - action: install_cab_fonts
-  url: temp/times32_exe
+  url: temp/times32
   fonts: 
    - Times.TTF
    - Timesbd.TTF
@@ -126,7 +137,7 @@ Steps:
    - Timesi.TTF
   
 - action: install_cab_fonts
-  url: temp/trebuc32_exe
+  url: temp/trebuc32
   fonts: 
    - trebuc.ttf
    - Trebucbd.ttf
@@ -134,7 +145,7 @@ Steps:
    - trebucit.ttf
   
 - action: install_cab_fonts
-  url: temp/verdan32_exe
+  url: temp/verdan32
   fonts: 
    - Verdanab.TTF
    - Verdanai.TTF
@@ -142,7 +153,7 @@ Steps:
    - Verdana.TTF
   
 - action: install_cab_fonts
-  url: temp/webdin32_exe
+  url: temp/webdin32
   fonts: 
    - Webdings.TTF
 

--- a/Fonts/andale32.yml
+++ b/Fonts/andale32.yml
@@ -9,6 +9,7 @@ Steps:
   file_name: andale32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/andale32.exe
   file_checksum: cbdc2fdd7d2ed0832795e86a8b9ee19a
+  dest: temp/andale32
   
 - action: install_cab_fonts
   url: temp/andale32

--- a/Fonts/arial32.yml
+++ b/Fonts/arial32.yml
@@ -9,6 +9,7 @@ Steps:
   file_name: arial32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/arial32.exe
   file_checksum: 9637df0e91703179f0723ec095a36cb5
+  dest: temp/arial32
 
 - action: install_cab_fonts
   url: temp/arial32

--- a/Fonts/arialb32.yml
+++ b/Fonts/arialb32.yml
@@ -9,6 +9,7 @@ Steps:
   file_name: arialb32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/arialb32.exe
   file_checksum: c9089ae0c3b3d0d8c4b0a95979bb9ff0
+  dest: temp/arialb32
 
 - action: install_cab_fonts
   url: temp/arialb32

--- a/Fonts/comic32.yml
+++ b/Fonts/comic32.yml
@@ -9,6 +9,7 @@ Steps:
   file_name: comic32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/comic32.exe
   file_checksum: 2b30de40bb5e803a0452c7715fc835d1
+  dest: temp/comic32
 
 - action: install_cab_fonts
   url: temp/comic32

--- a/Fonts/courie32.yml
+++ b/Fonts/courie32.yml
@@ -9,6 +9,7 @@ Steps:
   file_name: courie32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/courie32.exe
   file_checksum: 4e412c772294403ab62fb2d247d85c60
+  dest: temp/courie32
 
 - action: install_cab_fonts
   url: temp/courie32

--- a/Fonts/georgi32.yml
+++ b/Fonts/georgi32.yml
@@ -9,6 +9,7 @@ Steps:
   file_name: georgi32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/georgi32.exe
   file_checksum: 4d90016026e2da447593b41a8d8fa8bd
+  dest: temp/georgi32
 
 - action: install_cab_fonts
   url: temp/georgi32

--- a/Fonts/impact32.yml
+++ b/Fonts/impact32.yml
@@ -9,6 +9,7 @@ Steps:
   file_name: impact32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/impact32.exe
   file_checksum: 7907c7dd6684e9bade91cff82683d9d7
+  dest: temp/impact32
 
 - action: install_cab_fonts
   url: temp/impact32

--- a/Fonts/times32.yml
+++ b/Fonts/times32.yml
@@ -9,6 +9,7 @@ Steps:
   file_name: times32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/times32.exe
   file_checksum: ed39c8ef91b9fb80f76f702568291bd5
+  dest: temp/times32
 
 - action: install_cab_fonts
   url: temp/times32

--- a/Fonts/trebuc32.yml
+++ b/Fonts/trebuc32.yml
@@ -9,6 +9,7 @@ Steps:
   file_name: trebuc32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/trebuc32.exe
   file_checksum: 0d7ea16cac6261f8513a061fbfcdb2b5
+  dest: temp/trebuc32
     
 - action: install_cab_fonts
   url: temp/trebuc32

--- a/Fonts/verdan32.yml
+++ b/Fonts/verdan32.yml
@@ -9,6 +9,7 @@ Steps:
   file_name: verdan32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/verdan32.exe
   file_checksum: 12d2a75f8156e10607be1eaa8e8ef120
+  dest: temp/verdan32
 
 - action: install_cab_fonts
   url: temp/verdan32

--- a/Fonts/webdin32.yml
+++ b/Fonts/webdin32.yml
@@ -9,6 +9,7 @@ Steps:
   file_name: webdin32.exe
   url: https://sourceforge.net/projects/corefonts/files/the%20fonts/final/webdin32.exe
   file_checksum: 230a1d13a365b22815f502eb24d9149b
+  dest: temp/webdin32
 
 - action: install_cab_fonts
   url: temp/webdin32

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ extracted files will be placed in a new directory in the bottles'temp path, its 
 - action: copy_cab_dll
   file_name: msxml6.dll.86F857F6_A743_463D_B2FE_98CB5F727E09
   url: temp/msxml6
-  dest: windows/system32/msxml6.dll
+  dest: win32msxml6.dll
 ```
 
 **override_dll** can be used to add a new DLL override


### PR DESCRIPTION
Should be merged after 2022.1.14 release.

Fixes:
- d3dcompiler_43
- allfonts
- vcredist6
- msls31
- directx9
- msxml6

Other changes:
- removed deprecated `copy_cab_dll` action
- avoid to extract entire cabinets, just pick the needed resource
- every asset has its own directory in temp
- use new win32/win64 dest