### PR TITLE
Fix MS font names

### DIFF
--- a/Fonts/andale32.yml
+++ b/Fonts/andale32.yml
@@ -1,5 +1,5 @@
 Name: andale32
-Description: Andale Font 32 bit
+Description: Andale Mono Font
 Provider: Microsoft
 License: Microsoft EULA
 License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm

--- a/Fonts/comic32.yml
+++ b/Fonts/comic32.yml
@@ -1,5 +1,5 @@
 Name: comic32
-Description: Comic Sans Font
+Description: Comic Sans MS Font
 Provider: Microsoft
 License: Microsoft EULA
 License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm

--- a/Fonts/courie32.yml
+++ b/Fonts/courie32.yml
@@ -1,5 +1,5 @@
 Name: courie32
-Description: Courie Font
+Description: Courier New Font
 Provider: Microsoft
 License: Microsoft EULA
 License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm

--- a/Fonts/trebuc32.yml
+++ b/Fonts/trebuc32.yml
@@ -1,5 +1,5 @@
 Name: trebuc32
-Description: Trebuchet Font
+Description: Trebuchet MS Font
 Provider: Microsoft
 License: Microsoft EULA
 License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm

--- a/index.yml
+++ b/index.yml
@@ -130,10 +130,10 @@ arial32:
   Description: Microsoft Arial Font
   Category: Fonts
 comic32:
-  Description: Microsoft Comic Font
+  Description: Microsoft Comic Sans MS Font
   Category: Fonts
 courie32:
-  Description: Microsoft Courie Font
+  Description: Microsoft Courier New Font
   Category: Fonts
 times32:
   Description: Microsoft Times New Roman Font


### PR DESCRIPTION
Some of the font names are not matching with the official names and Courier font was missing the "r".