### PR TITLE
Update checksum of vcredist2019 (x64) to 35431d059197b67227cd12f841733539

### DIFF
--- a/Essentials/vcredist2019.yml
+++ b/Essentials/vcredist2019.yml
@@ -16,7 +16,7 @@ Steps:
   file_name: VC_redist.x64.exe
   url: https://aka.ms/vs/16/release/VC_redist.x64.exe
   rename: vcredist2019_x64.exe
-  file_checksum: 291e0c486cbe22cb000c5e541c9e8317
+  file_checksum: 35431d059197b67227cd12f841733539
   arguments: /quiet /norestart
 
 - action: override_dll


### PR DESCRIPTION
```
Downloading VC_redist.x64.exe: 100% [==================================================>

(14:20:52) INFO Renaming [VC_redist.x64.exe] to [vcredist2019_x64.exe]. 
(14:20:52) ERROR Downloaded file [VC_redist.x64.exe] looks corrupted. 
(14:20:52) ERROR Source cksum: [291e0c486cbe22cb000c5e541c9e8317] downloaded: [35431d059197b67227cd12f841733539] 
(14:20:52) INFO Removing corrupted file [VC_redist.x64.exe].
```