### PR TITLE
Essentials: add msftedit

### DIFF
--- a/Essentials/msftedit.yml
+++ b/Essentials/msftedit.yml
@@ -1,0 +1,34 @@
+Name: msftedit
+Description: Microsoft RichEdit Control 4.1 (msftedit.dll)
+Provider: Microsoft
+License: Microsoft EULA
+License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
+Dependencies: []
+Steps:
+  - action: download_archive
+    file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+    url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+    rename: windows6.1-kb976932-x86.exe
+    file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
+    file_size: 563934504
+
+  - action: download_archive
+    file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+    url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+    rename: windows6.1-kb976932-x64.exe
+    file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
+    file_size: 947070088
+
+  - action: get_from_cab
+    source: windows6.1-kb976932-x86.exe
+    file_name: x86_microsoft-windows-msftedit_31bf3856ad364e35_6.1.7601.17514_none_d7d862f19573a5ff/msftedit.dll
+    dest: win32
+
+  - action: get_from_cab
+    source: windows6.1-kb976932-x64.exe
+    file_name: amd64_microsoft-windows-msftedit_31bf3856ad364e35_6.1.7601.17514_none_33f6fe754dd11735/msftedit.dll
+    dest: win64
+
+  - action: override_dll
+    dll: msftedit
+    type: native, builtin

--- a/index.yml
+++ b/index.yml
@@ -1,5 +1,5 @@
+--- # ------------------------------
 # WINE
-# ------------------------------
 mono:
   Description: Wine mono
   Category: Essentials
@@ -85,8 +85,8 @@ aairruntime:
   Description: Harman AIR runtime
   Category: Essentials
 mfc40:
-   Description: Microsoft mfc40 Microsoft Foundation Classes
-   Category: Essentials
+  Description: Microsoft mfc40 Microsoft Foundation Classes
+  Category: Essentials
 msxml3:
   Description: Microsoft Core XML Services (MSXML) 3.0
   Category: Essentials
@@ -107,6 +107,9 @@ art2k7min:
   Category: Essentials
 riched20:
   Description: Microsoft RichEdit Control 2.0 (riched20.dll)
+  Category: Essentials
+msftedit:
+  Description: Microsoft RichEdit Control 4.1 (msftedit.dll)
   Category: Essentials
 msls31:
   Description: Microsoft Line Services
@@ -148,7 +151,7 @@ d3dcompiler_46:
 d3dcompiler_47:
   Description: Microsoft d3dcompiler_47.dll
   Category: Essentials
-  
+
 # CODECS
 # ------------------------------
 ffdshow:
@@ -157,7 +160,7 @@ ffdshow:
 dirac:
   Description: The Dirac directshow filter v1.0.2
   Category: Essentials
-  
+
 # FONTS
 # ------------------------------
 allfonts:


### PR DESCRIPTION
This PR adds the `msftedit` dependency manifest into the repository. The DLLs are pulled from Windows 7 SP1 installer ([winetricks reference](https://github.com/Winetricks/winetricks/blob/3997dacadc2938829412cd75d7395f123c36005b/src/winetricks))