### PR TITLE
Add lavfilters741

### DIFF
--- a/Essentials/lavfilters741.yml
+++ b/Essentials/lavfilters741.yml
@@ -1,0 +1,12 @@
+Name: lavfilters741
+Description: LAV Filters 0.74.1
+Provider: Hendrik Leppkes
+License: GPLv2
+License_url: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+Dependencies: []
+Steps:
+  - action: install_exe
+    file_name: LAVFilters-0.74.1-Installer.exe
+    url: https://github.com/Nevcairiel/LAVFilters/releases/download/0.74.1/LAVFilters-0.74.1-Installer.exe
+    file_checksum: d4044f1a0e84dc052c677bd88b40e62e
+    file_size: 12560912


### PR DESCRIPTION
Adds [LAV Filters 0.74.1](https://github.com/Nevcairiel/LAVFilters/releases/tag/0.74.1). 

This is the version [currently used by Winetricks](https://github.com/Winetricks/winetricks/blob/be6d44613eed10e8f6757b8df9fc5af80103f5c1/src/winetricks#L10793). Tested with caffe-7.7, in a 32-bit and 64-bit Wine bottle.

