### PR TITLE
Typo fix in index.yml

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -235,6 +235,6 @@ webdin32:
 consolas:
   Description: MS Consolas console font
   Category: Fonts
-lucom:
+lucon:
   Description: MS Lucida console font
   Category: Fonts


### PR DESCRIPTION
Change `lucom` to `lucon` to match `Fonts/lucon.yml`