### PR TITLE
Update d3dcompiler_47.yml

### DIFF
--- a/Essentials/d3dcompiler_47.yml
+++ b/Essentials/d3dcompiler_47.yml
@@ -21,3 +21,7 @@ Steps:
   url: temp/d3dx9.tar/d3dx9/win64/
   file_name: d3dcompiler*_47.dll
   dest: win64
+
+- action: override_dll
+  dll: d3dcompiler_47
+  type: native,builtin


### PR DESCRIPTION
Add missing override_dll action.

Fixes #(issue)
Anything that needs d3dcompiler_47, like Ubisoft Connect.

## Type of change
- [ ] New dependency
- [x] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [ ] Yes
- [x] No