### PR TITLE
add cnc-ddraw

### DIFF
--- a/Essentials/cnc-ddraw.yml
+++ b/Essentials/cnc-ddraw.yml
@@ -1,0 +1,30 @@
+Name: cnc-ddraw
+Description: Re-implementation of the DirectDraw API for classic games
+Provider: CnCNet
+License: MIT
+License_url: https://github.com/CnCNet/cnc-ddraw/blob/master/LICENSE
+Dependencies: []
+Steps:
+- action: archive_extract
+  file_name: cnc-ddraw.zip
+  url: https://github.com/CnCNet/cnc-ddraw/releases/download/v4.4.7.0/cnc-ddraw.zip
+  file_checksum: 771d76a65e328d0cff5dbe88296a15a9
+
+- action: copy_file
+  url: temp/cnc-ddraw/
+  file_name: '*.exe'
+  dest: win32
+
+- action: copy_file
+  url: temp/cnc-ddraw/
+  file_name: '*.dll'
+  dest: win32
+
+- action: copy_file
+  url: temp/cnc-ddraw/
+  file_name: '*.ini'
+  dest: win32
+
+- action: override_dll
+  dll: ddraw
+  type: native,builtin

--- a/index.yml
+++ b/index.yml
@@ -166,6 +166,9 @@ d3dcompiler_47:
 d3dx11:
   Description: Microsoft d3dx11 DLLs from DirectX 11 redistributable
   Category: Essentials
+cnc-ddraw:
+  Description: Re-implementation of the DirectDraw API for classic games
+  Category: Essentials
 
 # DXNT
 # ------------------------------


### PR DESCRIPTION
Fixes #118 

Note: does not copy the 'Shaders' directory provided by cnc-ddraw as there is no available action in the manifest to create a directory. Throws this error otherwise: `[Errno 2] No such file or directory: '/home/USER/.var/app/com.usebottles.bottles/data/bottles/bottles/test-bottle/drive_c/windows/syswow64//Shaders/nearest-neighbor.glsl'`

## Type of change
- [x] New dependency
- [ ] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
