### PR TITLE
Add mdac28.yml

### DIFF
--- a/Essentials/mdac28.yml
+++ b/Essentials/mdac28.yml
@@ -1,0 +1,26 @@
+Name: mdac28
+Description: Microsoft Data Access Components 2.8 SP1
+Provider: Microsoft
+License: Microsoft EULA
+License_url:
+Dependencies: []
+Steps:
+- action: set_windows
+  version: win98
+
+- action: override_dll
+  bundle:
+    - value: odbccp32
+      data: native,builtin
+    - value: mtxdm
+      data: native,builtin
+    - value: odbc32
+      data: native,builtin
+    - value: oledb32
+      data: native,builtin
+
+- action: install_exe
+  file_name: MDAC_TYP.EXE
+  url: https://web.archive.org/web/20070127061938/https://download.microsoft.com/download/4/a/a/4aafff19-9d21-4d35-ae81-02c48dcbbbff/MDAC_TYP.EXE
+  file_checksum: 6e914a7391c3b17380ce54fd3a7a133d
+  arguments: /q /C:"setup /qnt"

--- a/index.yml
+++ b/index.yml
@@ -96,6 +96,9 @@ aairruntime:
 gmdls:
   Description: General MIDI DLS Collection
   Category: Essentials
+mdac28:
+  Description: Microsoft Data Access Components 2.8 SP1
+  Category: Essentials
 mfc40:
   Description: Microsoft mfc40 Microsoft Foundation Classes
   Category: Essentials


### PR DESCRIPTION
Fixes https://github.com/bottlesdevs/dependencies/issues/114

Install log at drive_c/Windows/dasetup.log reads like it installed properly.

Currently receive `modify_ldt: Operation not permitted` during the exe install, but should be fixed by https://github.com/bottlesdevs/Bottles/issues/868#issuecomment-1238841726 

## Type of change
- [x] New dependency
- [ ] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
