### PR TITLE
add directshow components

### DIFF
--- a/Essentials/amstream.yml
+++ b/Essentials/amstream.yml
@@ -1,0 +1,39 @@
+Name: amstream
+Description: MS amstream.dll
+Provider: Microsoft
+License:
+License_url:
+Dependencies: []
+Steps:
+- action: cab_extract
+  file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  rename: windows6.1-kb976932-x86.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
+  dest: temp/windows6.1-kb976932-x86
+
+- action: cab_extract
+  file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  rename: windows6.1-kb976932-x64.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
+  dest: temp/windows6.1-kb976932-x64
+
+- action: copy_dll
+  file_name: 'amstream.dll'
+  url: temp/windows6.1-kb976932-x86/x86_microsoft-windows-directshow-other_31bf3856ad364e35_6.1.7601.17514_none_0f58f1e53efca91e
+  dest: win32
+
+- action: copy_dll
+  file_name: 'amstream.dll'
+  url: temp/windows6.1-kb976932-x64/amd64_microsoft-windows-directshow-other_31bf3856ad364e35_6.1.7601.17514_none_6b778d68f75a1a54
+  dest: win64
+
+- action: override_dll
+  bundle:
+    - value: amstream
+      data: native,builtin
+
+- action: register_dll
+  dlls:
+    - amstream.dll

--- a/Essentials/directshow.yml
+++ b/Essentials/directshow.yml
@@ -1,0 +1,13 @@
+Name: directshow
+Description: All Microsoft DirectShow dependencies
+Provider: Microsoft
+License: Microsoft EULA
+License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
+Dependencies:
+  - amstream
+  - qasf
+  - qcap
+  - qdvd
+  - qedit
+  - quartz
+Steps: []

--- a/Essentials/qasf.yml
+++ b/Essentials/qasf.yml
@@ -1,0 +1,39 @@
+Name: qasf
+Description: MS qasf.dll
+Provider: Microsoft
+License:
+License_url:
+Dependencies: []
+Steps:
+- action: cab_extract
+  file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  rename: windows6.1-kb976932-x86.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
+  dest: temp/windows6.1-kb976932-x86
+
+- action: cab_extract
+  file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  rename: windows6.1-kb976932-x64.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
+  dest: temp/windows6.1-kb976932-x64
+
+- action: copy_dll
+  file_name: 'qasf.dll'
+  url: temp/windows6.1-kb976932-x86/x86_microsoft-windows-directshow-asf_31bf3856ad364e35_6.1.7601.17514_none_1cc4e9c15ccc8ae8
+  dest: win32
+
+- action: copy_dll
+  file_name: 'qasf.dll'
+  url: temp/windows6.1-kb976932-x64/amd64_microsoft-windows-directshow-asf_31bf3856ad364e35_6.1.7601.17514_none_78e385451529fc1e
+  dest: win64
+
+- action: override_dll
+  bundle:
+    - value: qasf
+      data: native,builtin
+
+- action: register_dll
+  dlls:
+    - qasf.dll

--- a/Essentials/qcap.yml
+++ b/Essentials/qcap.yml
@@ -1,0 +1,39 @@
+Name: qcap
+Description: MS qcap.dll
+Provider: Microsoft
+License:
+License_url:
+Dependencies: []
+Steps:
+- action: cab_extract
+  file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  rename: windows6.1-kb976932-x86.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
+  dest: temp/windows6.1-kb976932-x86
+
+- action: cab_extract
+  file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  rename: windows6.1-kb976932-x64.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
+  dest: temp/windows6.1-kb976932-x64
+
+- action: copy_dll
+  file_name: 'qcap.dll'
+  url: temp/windows6.1-kb976932-x86/x86_microsoft-windows-directshow-capture_31bf3856ad364e35_6.1.7601.17514_none_bae08d1e7dcccf2a
+  dest: win32
+
+- action: copy_dll
+  file_name: 'qcap.dll'
+  url: temp/windows6.1-kb976932-x64/amd64_microsoft-windows-directshow-capture_31bf3856ad364e35_6.1.7601.17514_none_16ff28a2362a4060
+  dest: win64
+
+- action: override_dll
+  bundle:
+    - value: qcap
+      data: native,builtin
+
+- action: register_dll
+  dlls:
+    - qcap.dll

--- a/Essentials/qdvd.yml
+++ b/Essentials/qdvd.yml
@@ -1,0 +1,39 @@
+Name: qdvd
+Description: MS qdvd.dll
+Provider: Microsoft
+License:
+License_url:
+Dependencies: []
+Steps:
+- action: cab_extract
+  file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  rename: windows6.1-kb976932-x86.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
+  dest: temp/windows6.1-kb976932-x86
+
+- action: cab_extract
+  file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  rename: windows6.1-kb976932-x64.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
+  dest: temp/windows6.1-kb976932-x64
+
+- action: copy_dll
+  file_name: 'qdvd.dll'
+  url: temp/windows6.1-kb976932-x86/x86_microsoft-windows-directshow-dvdsupport_31bf3856ad364e35_6.1.7601.17514_none_562994bd321aac67
+  dest: win32
+
+- action: copy_dll
+  file_name: 'qdvd.dll'
+  url: temp/windows6.1-kb976932-x64/amd64_microsoft-windows-directshow-dvdsupport_31bf3856ad364e35_6.1.7601.17514_none_b2483040ea781d9d
+  dest: win64
+
+- action: override_dll
+  bundle:
+    - value: qdvd
+      data: native,builtin
+
+- action: register_dll
+  dlls:
+    - qdvd.dll

--- a/Essentials/qedit.yml
+++ b/Essentials/qedit.yml
@@ -1,0 +1,39 @@
+Name: qedit
+Description: MS qedit.dll
+Provider: Microsoft
+License:
+License_url:
+Dependencies: []
+Steps:
+- action: cab_extract
+  file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  rename: windows6.1-kb976932-x86.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
+  dest: temp/windows6.1-kb976932-x86
+
+- action: cab_extract
+  file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  rename: windows6.1-kb976932-x64.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
+  dest: temp/windows6.1-kb976932-x64
+
+- action: copy_dll
+  file_name: 'qedit.dll'
+  url: temp/windows6.1-kb976932-x86/x86_microsoft-windows-qedit_31bf3856ad364e35_6.1.7601.17514_none_5ca34698a5a970d2
+  dest: win32
+
+- action: copy_dll
+  file_name: 'qedit.dll'
+  url: temp/windows6.1-kb976932-x64/amd64_microsoft-windows-qedit_31bf3856ad364e35_6.1.7601.17514_none_b8c1e21c5e06e208
+  dest: win64
+
+- action: override_dll
+  bundle:
+    - value: qedit
+      data: native,builtin
+
+- action: register_dll
+  dlls:
+    - qedit.dll

--- a/Essentials/quartz.yml
+++ b/Essentials/quartz.yml
@@ -1,0 +1,39 @@
+Name: quartz
+Description: MS quartz.dll
+Provider: Microsoft
+License:
+License_url:
+Dependencies: []
+Steps:
+- action: cab_extract
+  file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  rename: windows6.1-kb976932-x86.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
+  dest: temp/windows6.1-kb976932-x86
+
+- action: cab_extract
+  file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  rename: windows6.1-kb976932-x64.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
+  dest: temp/windows6.1-kb976932-x64
+
+- action: copy_dll
+  file_name: 'quartz.dll'
+  url: temp/windows6.1-kb976932-x86/x86_microsoft-windows-directshow-core_31bf3856ad364e35_6.1.7601.17514_none_a877a1cc4c284497
+  dest: win32
+
+- action: copy_dll
+  file_name: 'quartz.dll'
+  url: temp/windows6.1-kb976932-x64/amd64_microsoft-windows-directshow-core_31bf3856ad364e35_6.1.7601.17514_none_04963d500485b5cd
+  dest: win64
+
+- action: override_dll
+  bundle:
+    - value: quartz
+      data: native,builtin
+
+- action: register_dll
+  dlls:
+    - quartz.dll

--- a/index.yml
+++ b/index.yml
@@ -184,11 +184,17 @@ dx8vb:
 
 # DXNT
 # ------------------------------
+amstream:
+  Description: Microsoft amstream.dll
+  Category: Essentials
 directplay:
   Description: Microsoft DirectPlay redistributable
   Category: Essentials
 directmusic:
   Description: All Microsoft DirectMusic dependencies
+  Category: Essentials
+directshow:
+  Description: All Microsoft DirectShow dependencies
   Category: Essentials
 dmband:
   Description: Microsoft dmband.dll
@@ -225,6 +231,21 @@ dswave:
   Category: Essentials
 dsdmo:
   Description: Microsoft dsdmo.dll
+  Category: Essentials
+qasf:
+  Description: Microsoft qasf.dll
+  Category: Essentials
+qcap:
+  Description: Microsoft qcap.dll
+  Category: Essentials
+qdvd:
+  Description: Microsoft qdvd.dll
+  Category: Essentials
+qedit:
+  Description: Microsoft qedit.dll
+  Category: Essentials
+quartz:
+  Description: Microsoft quartz.dll
   Category: Essentials
 
 # XNA


### PR DESCRIPTION
Fixes https://github.com/bottlesdevs/dependencies/issues/67 

Adds the directshow components per Winetricks' implementation. Tested with GOG versions of MGS2 and Trails of Cold Steel.

  - amstream
  - qasf
  - qcap
  - qdvd
  - qedit
  - quartz

## Type of change
- [x] New dependency
- [ ] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
