### PR TITLE
Add gfw, msasn1, xact, xinput

### DIFF
--- a/Essentials/gfw.yml
+++ b/Essentials/gfw.yml
@@ -1,0 +1,12 @@
+Name: gfw
+Description: MS Games For Windows Live (xlive.dll)
+Provider: Microsoft
+License:
+License_url:
+Dependencies: []
+Steps:
+- action: install_exe
+  file_name: gfwlivesetupmin.exe
+  url: https://web.archive.org/web/20140730232216/https://download.microsoft.com/download/5/5/8/55846E20-4A46-4EF8-B272-7F988BC9090A/gfwlivesetupmin.exe
+  arguments: [/nodotnet /q]
+  file_checksum: c0d501ef65af23efa0b2414e9b85ff66

--- a/Essentials/msasn1.yml
+++ b/Essentials/msasn1.yml
@@ -1,0 +1,17 @@
+Name: msasn1
+Description: MS ASN1
+Provider: Microsoft
+License:
+License_url:
+Dependencies: []
+Steps:
+- action: cab_extract
+  file_name: W2KSP4_EN.EXE
+  url: http://x3270.bgp.nu/download/specials/W2KSP4_EN.EXE
+  file_checksum: a4ef6c91d418418b287cefe31f958175
+  dest: temp/W2KSP4_EN
+
+- action: copy_file
+  file_name: 'msasn1.dl_'
+  url: temp/W2KSP4_EN/i386/
+  dest: win64

--- a/Essentials/xact.yml
+++ b/Essentials/xact.yml
@@ -1,0 +1,159 @@
+Name: xact
+Description: MS XACT Engine (32-bit only)
+Provider: Microsoft
+License:
+License_url:
+Dependencies: []
+Steps:
+- action: download_archive
+  file_name: directx_Jun2010_redist.exe
+  url: https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe
+  file_checksum: 822e4c516600e81dc7fb16d9a77ec6d4
+
+- action: get_from_cab
+  source: directx_Jun2010_redist.exe
+  file_name: '*XACT_x86*.cab'
+  dest: temp/XACT_x86/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist.exe
+  file_name: '*X3DAUDIO_x86*.cab'
+  dest: temp/XACT_x86/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist.exe
+  file_name: '*XAUDIO_x86*.cab'
+  dest: temp/XACT_x86/
+
+- action: get_from_cab
+  source: XACT_x86/*.cab
+  file_name: 'xactengine*.dll'
+  dest: win32/
+
+- action: get_from_cab
+  source: XACT_x86/*.cab
+  file_name: 'xaudio*.dll'
+  dest: win32/
+
+- action: get_from_cab
+  source: XACT_x86/*.cab
+  file_name: 'x3daudio*.dll'
+  dest: win32/
+
+- action: get_from_cab
+  source: XACT_x86/*.cab
+  file_name: 'xapofx*.dll'
+  dest: win32/
+
+- action: override_dll
+  bundle: 
+    - value: xaudio2_0
+      data: native,builtin
+    - value: xaudio2_1 
+      data: native,builtin
+    - value: xaudio2_2
+      data: native,builtin
+    - value: xaudio2_3
+      data: native,builtin
+    - value: xaudio2_4
+      data: native,builtin
+    - value: xaudio2_5
+      data: native,builtin
+    - value: xaudio2_6
+      data: native,builtin
+    - value: xaudio2_7
+      data: native,builtin
+    - value: x3daudio1_0
+      data: native,builtin
+    - value: x3daudio1_1
+      data: native,builtin
+    - value: x3daudio1_2
+      data: native,builtin
+    - value: x3daudio1_3
+      data: native,builtin
+    - value: x3daudio1_4
+      data: native,builtin
+    - value: x3daudio1_5
+      data: native,builtin
+    - value: x3daudio1_6
+      data: native,builtin
+    - value: x3daudio1_7
+      data: native,builtin
+    - value: xapofx1_1
+      data: native,builtin
+    - value: xapofx1_2
+      data: native,builtin
+    - value: xapofx1_3
+      data: native,builtin
+    - value: xapofx1_4
+      data: native,builtin
+    - value: xapofx1_5
+      data: native,builtin
+    - value: xactengine2_0
+      data: native,builtin
+    - value: xactengine2_1
+      data: native,builtin
+    - value: xactengine2_2
+      data: native,builtin
+    - value: xactengine2_3
+      data: native,builtin
+    - value: xactengine2_4
+      data: native,builtin
+    - value: xactengine2_5
+      data: native,builtin
+    - value: xactengine2_6
+      data: native,builtin
+    - value: xactengine2_7
+      data: native,builtin
+    - value: xactengine2_8
+      data: native,builtin
+    - value: xactengine2_9
+      data: native,builtin
+    - value: xactengine2_10
+      data: native,builtin
+    - value: xactengine3_0
+      data: native,builtin
+    - value: xactengine3_1
+      data: native,builtin
+    - value: xactengine3_2
+      data: native,builtin
+    - value: xactengine3_3
+      data: native,builtin
+    - value: xactengine3_4
+      data: native,builtin
+    - value: xactengine3_5
+      data: native,builtin
+    - value: xactengine3_6
+      data: native,builtin
+    - value: xactengine3_7
+      data: native,builtin
+
+- action: register_dll
+  dlls:
+    - xactengine2_0.dll
+    - xactengine2_1.dll
+    - xactengine2_2.dll
+    - xactengine2_3.dll
+    - xactengine2_4.dll
+    - xactengine2_5.dll
+    - xactengine2_6.dll
+    - xactengine2_7.dll
+    - xactengine2_8.dll
+    - xactengine2_9.dll
+    - xactengine2_10.dll
+    - xactengine3_0.dll
+    - xactengine3_1.dll
+    - xactengine3_2.dll
+    - xactengine3_3.dll
+    - xactengine3_4.dll
+    - xactengine3_5.dll
+    - xactengine3_6.dll
+    - xactengine3_7.dll
+    - xaudio2_0.dll
+    - xaudio2_1.dll
+    - xaudio2_2.dll
+    - xaudio2_3.dll
+    - xaudio2_4.dll
+    - xaudio2_5.dll
+    - xaudio2_6.dll
+    - xaudio2_7.dll

--- a/Essentials/xact_x64.yml
+++ b/Essentials/xact_x64.yml
@@ -1,0 +1,159 @@
+Name: xact_x64
+Description: MS XACT Engine (64-bit only)
+Provider: Microsoft
+License:
+License_url:
+Dependencies: []
+Steps:
+- action: download_archive
+  file_name: directx_Jun2010_redist.exe
+  url: https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe
+  file_checksum: 822e4c516600e81dc7fb16d9a77ec6d4
+
+- action: get_from_cab
+  source: directx_Jun2010_redist.exe
+  file_name: '*XACT_x64*.cab'
+  dest: temp/XACT_x64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist.exe
+  file_name: '*X3DAUDIO_x64*.cab'
+  dest: temp/XACT_x64/
+
+- action: get_from_cab
+  source: directx_Jun2010_redist.exe
+  file_name: '*XAUDIO_x64*.cab'
+  dest: temp/XACT_x64/
+
+- action: get_from_cab
+  source: XACT_x64/*.cab
+  file_name: 'xactengine*.dll'
+  dest: win64/
+
+- action: get_from_cab
+  source: XACT_x64/*.cab
+  file_name: 'xaudio*.dll'
+  dest: win64/
+
+- action: get_from_cab
+  source: XACT_x64/*.cab
+  file_name: 'x3daudio*.dll'
+  dest: win64/
+
+- action: get_from_cab
+  source: XACT_x64/*.cab
+  file_name: 'xapofx*.dll'
+  dest: win64/
+
+- action: override_dll
+  bundle: 
+    - value: xaudio2_0
+      data: native,builtin
+    - value: xaudio2_1 
+      data: native,builtin
+    - value: xaudio2_2
+      data: native,builtin
+    - value: xaudio2_3
+      data: native,builtin
+    - value: xaudio2_4
+      data: native,builtin
+    - value: xaudio2_5
+      data: native,builtin
+    - value: xaudio2_6
+      data: native,builtin
+    - value: xaudio2_7
+      data: native,builtin
+    - value: x3daudio1_0
+      data: native,builtin
+    - value: x3daudio1_1
+      data: native,builtin
+    - value: x3daudio1_2
+      data: native,builtin
+    - value: x3daudio1_3
+      data: native,builtin
+    - value: x3daudio1_4
+      data: native,builtin
+    - value: x3daudio1_5
+      data: native,builtin
+    - value: x3daudio1_6
+      data: native,builtin
+    - value: x3daudio1_7
+      data: native,builtin
+    - value: xapofx1_1
+      data: native,builtin
+    - value: xapofx1_2
+      data: native,builtin
+    - value: xapofx1_3
+      data: native,builtin
+    - value: xapofx1_4
+      data: native,builtin
+    - value: xapofx1_5
+      data: native,builtin
+    - value: xactengine2_0
+      data: native,builtin
+    - value: xactengine2_1
+      data: native,builtin
+    - value: xactengine2_2
+      data: native,builtin
+    - value: xactengine2_3
+      data: native,builtin
+    - value: xactengine2_4
+      data: native,builtin
+    - value: xactengine2_5
+      data: native,builtin
+    - value: xactengine2_6
+      data: native,builtin
+    - value: xactengine2_7
+      data: native,builtin
+    - value: xactengine2_8
+      data: native,builtin
+    - value: xactengine2_9
+      data: native,builtin
+    - value: xactengine2_10
+      data: native,builtin
+    - value: xactengine3_0
+      data: native,builtin
+    - value: xactengine3_1
+      data: native,builtin
+    - value: xactengine3_2
+      data: native,builtin
+    - value: xactengine3_3
+      data: native,builtin
+    - value: xactengine3_4
+      data: native,builtin
+    - value: xactengine3_5
+      data: native,builtin
+    - value: xactengine3_6
+      data: native,builtin
+    - value: xactengine3_7
+      data: native,builtin
+
+- action: register_dll
+  dlls:
+    - xactengine2_0.dll
+    - xactengine2_1.dll
+    - xactengine2_2.dll
+    - xactengine2_3.dll
+    - xactengine2_4.dll
+    - xactengine2_5.dll
+    - xactengine2_6.dll
+    - xactengine2_7.dll
+    - xactengine2_8.dll
+    - xactengine2_9.dll
+    - xactengine2_10.dll
+    - xactengine3_0.dll
+    - xactengine3_1.dll
+    - xactengine3_2.dll
+    - xactengine3_3.dll
+    - xactengine3_4.dll
+    - xactengine3_5.dll
+    - xactengine3_6.dll
+    - xactengine3_7.dll
+    - xaudio2_0.dll
+    - xaudio2_1.dll
+    - xaudio2_2.dll
+    - xaudio2_3.dll
+    - xaudio2_4.dll
+    - xaudio2_5.dll
+    - xaudio2_6.dll
+    - xaudio2_7.dll

--- a/Essentials/xinput.yml
+++ b/Essentials/xinput.yml
@@ -1,0 +1,37 @@
+Name: xinput
+Description: Microsoft XInput (Xbox controller support)
+Provider: Microsoft
+License:
+License_url:
+Dependencies: []
+Steps:
+- action: download_archive
+  file_name: directx_Jun2010_redist.exe
+  url: https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe
+  file_checksum: 822e4c516600e81dc7fb16d9a77ec6d4
+
+- action: get_from_cab
+  source: directx_Jun2010_redist.exe
+  file_name: '*XINPUT*.cab'
+  dest: temp/XINPUT/
+
+- action: get_from_cab
+  source: XINPUT/*x86*.cab
+  file_name: '*.dll'
+  dest: win32/
+
+- action: get_from_cab
+  source: XINPUT/*x64*.cab
+  file_name: '*.dll'
+  dest: win64/
+
+- action: override_dll
+  bundle: 
+    - value: xinput1_1
+      data: native,builtin
+    - value: xinput1_2
+      data: native,builtin
+    - value: xinput1_3
+      data: native,builtin
+    - value: xinput9_1_0
+      data: native,builtin

--- a/index.yml
+++ b/index.yml
@@ -96,6 +96,9 @@ winhttp:
 aairruntime:
   Description: Harman AIR runtime
   Category: Essentials
+gfw:
+  Description: MS Games For Windows Live (xlive.dll)
+  Category: Essentials
 gmdls:
   Description: General MIDI DLS Collection
   Category: Essentials
@@ -104,6 +107,9 @@ mdac28:
   Category: Essentials
 mfc40:
   Description: Microsoft mfc40 Microsoft Foundation Classes
+  Category: Essentials
+msasn1:
+  Description: MS ASN1
   Category: Essentials
 mspatcha:
   Description: Microsoft mspatcha.dll
@@ -153,7 +159,15 @@ physx:
 quicktime72:
   Description: QuickTime 7.2.0.240
   Category: Essentials
-
+xact:
+  Description: MS XACT Engine (32-bit only)
+  Category: Essentials
+xact_x64:
+  Description: MS XACT Engine (64-bit only)
+  Category: Essentials
+xinput:
+  Description: Microsoft XInput (Xbox controller support)
+  Category: Essentials
 ie8_kb2936068:
   Description: Cumulative Security Update for Internet Explorer 8
   Category: Essentials


### PR DESCRIPTION
Fixes https://github.com/bottlesdevs/dependencies/issues/143

Based on the winetricks implementation.

## Type of change
- [x] New dependency
- [ ] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No

Could not test in a 32-bit bottle as the dependency system for those are broken right now. Did not test with any games/applications that require these files.