### PR TITLE
Installing of riched20 fails

### DIFF
--- a/Essentials/riched20.yml
+++ b/Essentials/riched20.yml
@@ -15,7 +15,7 @@ Steps:
 - action: get_from_cab
   source: w2ksp4_en.exe
   file_name: riched20.dl_
-  dest: temp/riched20/
+  dest: temp/riched20/i386/
 
 - action: get_from_cab
   source: riched20/i386/riched20.dl_


### PR DESCRIPTION
Installing the depency riched20 fails, because of:  (ERROR) Cab file /home/user/.local/share/bottles/temp/riched20/i386/riched20.dl_ not found

This happens, because riched20.dl_ gets extracted to temp/riched20/ instead to /riched20/i386/riched20/

This fixes this.

Fixes #(issue)

## Type of change
- [ ] New dependency
- [x] Manifest fix
- [ ] Other

# Whas This Tested Using a [Local Repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
