### PR TITLE
Adding iertutil, urlmon, and wininet dependencies

### DIFF
--- a/Essentials/iertutil.yml
+++ b/Essentials/iertutil.yml
@@ -1,0 +1,34 @@
+Name: iertutil
+Description: Microsoft iertutil Microsoft Foundation Classes from win7sp1
+Provider: Microsoft
+License: Microsoft EULA
+License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
+Dependencies: []
+Steps:
+- action: cab_extract
+  file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  rename: windows6.1-kb976932-x86.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
+  dest: temp/windows6.1-kb976932-x86
+
+- action: cab_extract
+  file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  rename: windows6.1-kb976932-x64.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
+  dest: temp/windows6.1-kb976932-x64
+
+- action: copy_dll
+  file_name: 'iertutil.dll'
+  url: temp/windows6.1-kb976932-x86/x86_microsoft-windows-ie-runtimeutilities_31bf3856ad364e35_8.0.7601.17514_none_64655b7c61c841cb
+  dest: win32/
+
+- action: copy_dll
+  file_name: 'iertutil.dll'
+  url: temp/windows6.1-kb976932-x64/amd64_microsoft-windows-ie-runtimeutilities_31bf3856ad364e35_8.0.7601.17514_none_c083f7001a25b301
+  dest: win64/
+
+- action: override_dll
+  dll: iertutil
+  type: native,builtin

--- a/Essentials/iertutil.yml
+++ b/Essentials/iertutil.yml
@@ -8,14 +8,14 @@ Steps:
 - action: cab_extract
   file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
   rename: windows6.1-kb976932-x86.exe
-  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  url: https://proxy.usebottles.com/redistributable/dependencies/windows6.1-kb976932-x86.exe
   file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
   dest: temp/windows6.1-kb976932-x86
 
 - action: cab_extract
   file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
   rename: windows6.1-kb976932-x64.exe
-  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  url: https://proxy.usebottles.com/redistributable/dependencies/windows6.1-kb976932-x64.exe
   file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
   dest: temp/windows6.1-kb976932-x64
 

--- a/Essentials/urlmon.yml
+++ b/Essentials/urlmon.yml
@@ -1,0 +1,34 @@
+Name: urlmon
+Description: Microsoft urlmon Microsoft Foundation Classes from win7sp1
+Provider: Microsoft
+License: Microsoft EULA
+License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
+Dependencies: []
+Steps:
+- action: cab_extract
+  file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  rename: windows6.1-kb976932-x86.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
+  dest: temp/windows6.1-kb976932-x86
+
+- action: cab_extract
+  file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  rename: windows6.1-kb976932-x64.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
+  dest: temp/windows6.1-kb976932-x64
+
+- action: copy_dll
+  file_name: 'urlmon.dll'
+  url: temp/windows6.1-kb976932-x86/x86_microsoft-windows-i..ersandsecurityzones_31bf3856ad364e35_8.0.7601.17514_none_d1a4c8feac0dfcdb
+  dest: win32/
+
+- action: copy_dll
+  file_name: 'urlmon.dll'
+  url: temp/windows6.1-kb976932-x64/amd64_microsoft-windows-i..ersandsecurityzones_31bf3856ad364e35_8.0.7601.17514_none_2dc36482646b6e11
+  dest: win64/
+
+- action: override_dll
+  dll: urlmon
+  type: native,builtin

--- a/Essentials/urlmon.yml
+++ b/Essentials/urlmon.yml
@@ -8,14 +8,14 @@ Steps:
 - action: cab_extract
   file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
   rename: windows6.1-kb976932-x86.exe
-  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  url: https://proxy.usebottles.com/redistributable/dependencies/windows6.1-kb976932-x86.exe
   file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
   dest: temp/windows6.1-kb976932-x86
 
 - action: cab_extract
   file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
   rename: windows6.1-kb976932-x64.exe
-  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  url: https://proxy.usebottles.com/redistributable/dependencies/windows6.1-kb976932-x64.exe
   file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
   dest: temp/windows6.1-kb976932-x64
 

--- a/Essentials/wininet.yml
+++ b/Essentials/wininet.yml
@@ -30,5 +30,5 @@ Steps:
   dest: win64/
 
 - action: override_dll
-  dll: urlmon
+  dll: wininet
   type: native,builtin

--- a/Essentials/wininet.yml
+++ b/Essentials/wininet.yml
@@ -1,0 +1,34 @@
+Name: wininet
+Description: Microsoft wininet Microsoft Foundation Classes from win7sp1
+Provider: Microsoft
+License: Microsoft EULA
+License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
+Dependencies: []
+Steps:
+- action: cab_extract
+  file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  rename: windows6.1-kb976932-x86.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
+  dest: temp/windows6.1-kb976932-x86
+
+- action: cab_extract
+  file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  rename: windows6.1-kb976932-x64.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
+  dest: temp/windows6.1-kb976932-x64
+
+- action: copy_dll
+  file_name: 'wininet.dll'
+  url: temp/windows6.1-kb976932-x86/x86_microsoft-windows-i..tocolimplementation_31bf3856ad364e35_8.0.7601.17514_none_1eaaa4a07717236e
+  dest: win32/
+
+- action: copy_dll
+  file_name: 'wininet.dll'
+  url: temp/windows6.1-kb976932-x64/amd64_microsoft-windows-i..tocolimplementation_31bf3856ad364e35_8.0.7601.17514_none_7ac940242f7494a4
+  dest: win64/
+
+- action: override_dll
+  dll: urlmon
+  type: native,builtin

--- a/Essentials/wininet.yml
+++ b/Essentials/wininet.yml
@@ -8,14 +8,14 @@ Steps:
 - action: cab_extract
   file_name: windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
   rename: windows6.1-kb976932-x86.exe
-  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x86_c3516bc5c9e69fee6d9ac4f981f5b95977a8a2fa.exe
+  url: https://proxy.usebottles.com/redistributable/dependencies/windows6.1-kb976932-x86.exe
   file_checksum: 4bf28fc00d86c936c89e2d91ef46758b
   dest: temp/windows6.1-kb976932-x86
 
 - action: cab_extract
   file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
   rename: windows6.1-kb976932-x64.exe
-  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
+  url: https://proxy.usebottles.com/redistributable/dependencies/windows6.1-kb976932-x64.exe
   file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
   dest: temp/windows6.1-kb976932-x64
 

--- a/index.yml
+++ b/index.yml
@@ -93,6 +93,15 @@ dotnetcoredesktop6:
 winhttp:
   Description: Microsoft Windows HTTP Services
   Category: Essentials
+wininet:
+  Description: Windows Internet API
+  Category: Essentials
+urlmon:
+  Description: Uniform Resource Locator Moniker
+  Category: Essentials
+iertutil:
+  Description: Internet Explorer Run-Time Utility Library
+  Category: Essentials
 aairruntime:
   Description: Harman AIR runtime
   Category: Essentials


### PR DESCRIPTION
Adding iertutil, urlmon, and wininet dlls. Equivalent of the same installations that exist in winetricks. These are required to get Dark and Darker working, and was testing locally and confirmed to get that running properly.

## Type of change
- [x] New dependency
- [ ] Manifest fix
- [ ] Other

# Was this tested using a [local repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
