### PR TITLE
Add lavfilters702 and wsh57

### DIFF
--- a/Essentials/lavfilters702.yml
+++ b/Essentials/lavfilters702.yml
@@ -1,0 +1,12 @@
+Name: lavfilters702
+Description: LAV Filters 0.70.2
+Provider: Hendrik Leppkes
+License: GPLv2
+License_url: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+Dependencies: []
+Steps:
+  - action: install_exe
+    file_name: LAVFilters-0.70.2-Installer.exe
+    url: https://github.com/Nevcairiel/LAVFilters/releases/download/0.70.2/LAVFilters-0.70.2-Installer.exe
+    file_checksum: dde6b5238960ac0b67620f7fc52f200d
+    file_size: 10743016

--- a/Essentials/wsh57.yml
+++ b/Essentials/wsh57.yml
@@ -2,7 +2,7 @@ Name: wsh57
 Description: MS Windows Script Host 5.7
 Provider: Microsoft
 License: Microsoft
-License_url: https://download.microsoft.com/download/4/4/d/44de8a9e-630d-4c10-9f17-b9b34d3f6417/scripten.exe
+License_url: https://www.microsoft.com/en-us/download/details.aspx?id=8247
 Dependencies: []
 Steps:
 - action: download_archive

--- a/Essentials/wsh57.yml
+++ b/Essentials/wsh57.yml
@@ -1,0 +1,41 @@
+Name: wsh57
+Description: MS Windows Script Host 5.7
+Provider: Microsoft
+License:
+License_url:
+Dependencies: []
+Steps:
+- action: download_archive
+  file_name: scripten.exe
+  url: https://download.microsoft.com/download/4/4/d/44de8a9e-630d-4c10-9f17-b9b34d3f6417/scripten.exe
+  file_checksum: 65a8ebf870420316a939ac44fd4c731d
+  file_size: 1079152
+
+- action: get_from_cab
+  source: scripten.exe 
+  file_name: '*'
+  dest: win32/
+
+- action: override_dll
+  bundle: 
+    - value: jscript
+      data: native,builtin
+    - value: scrrun
+      data: native,builtin
+    - value: vbscript
+      data: native,builtin
+    - value: cscript.exe
+      data: native,builtin
+    - value: wscript.exe
+      data: native,builtin
+
+- action: register_dll
+  dlls:
+    - dispex.dll
+    - jscript.dll
+    - scrobj.dll
+    - scrrun.dll
+    - vbscript.dll
+    - wshcon.dll
+    - wshext.dll
+

--- a/Essentials/wsh57.yml
+++ b/Essentials/wsh57.yml
@@ -1,8 +1,8 @@
 Name: wsh57
 Description: MS Windows Script Host 5.7
 Provider: Microsoft
-License:
-License_url:
+License: Microsoft
+License_url: https://download.microsoft.com/download/4/4/d/44de8a9e-630d-4c10-9f17-b9b34d3f6417/scripten.exe
 Dependencies: []
 Steps:
 - action: download_archive


### PR DESCRIPTION
## Type of change
- [x] New dependency
- [ ] Manifest fix
- [ ] Other

# Was this tested using a [local repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No

Based on the Winetricks implementations of [LAV Filters 0.70.2](https://github.com/Winetricks/winetricks/blob/9899670f459425eade737a249b775f966ac63647/src/winetricks#L11211) and [MS Windows Script Host 5.7](https://github.com/Winetricks/winetricks/blob/9899670f459425eade737a249b775f966ac63647/src/winetricks#L13752).

Both dependencies were tested with caffe-7.7 in a 64-bit bottle.