### PR TITLE
Update arial32, times32, verdan32 font urls

### DIFF
--- a/Fonts/arial32.yml
+++ b/Fonts/arial32.yml
@@ -7,7 +7,7 @@ Dependencies: []
 Steps:
 - action: cab_extract
   file_name: arial32.exe
-  url: https://mirrors.kernel.org/gentoo/distfiles/5e/arial32.exe
+  url: https://cfhcable.dl.sourceforge.net/project/corefonts/the%20fonts/final/arial32.exe
   file_checksum: 9637df0e91703179f0723ec095a36cb5
   file_size: 554208
   dest: temp/arial32

--- a/Fonts/times32.yml
+++ b/Fonts/times32.yml
@@ -7,7 +7,7 @@ Dependencies: []
 Steps:
 - action: cab_extract
   file_name: times32.exe
-  url: https://mirrors.kernel.org/gentoo/distfiles/fe/times32.exe
+  url: https://versaweb.dl.sourceforge.net/project/corefonts/the%20fonts/final/times32.exe
   file_checksum: ed39c8ef91b9fb80f76f702568291bd5
   file_size: 661728
   dest: temp/times32

--- a/Fonts/verdan32.yml
+++ b/Fonts/verdan32.yml
@@ -7,7 +7,7 @@ Dependencies: []
 Steps:
 - action: cab_extract
   file_name: verdan32.exe
-  url: https://mirrors.kernel.org/gentoo/distfiles/a1/verdan32.exe
+  url: https://cytranet.dl.sourceforge.net/project/corefonts/the%20fonts/final/verdan32.exe
   file_checksum: 12d2a75f8156e10607be1eaa8e8ef120
   file_size: 351992
   dest: temp/verdan32


### PR DESCRIPTION
Fixes #203, #205, [#3125](https://github.com/bottlesdevs/Bottles/issues/3125), [#3144](https://github.com/bottlesdevs/Bottles/issues/3144)

## Type of change
- [ ] New dependency
- [ x] Manifest fix
- [ ] Other

# Was this tested using a [local repository](https://maintainers.usebottles.com/Testing)?
- [ ] Yes
- [x ] No


These files no longer exist at the previous urls and the mirrors no longer seem to provide them in general. Use [SourceForge](https://sourceforge.net/) mirrors for lack of a better provider.