### PR TITLE
Reverting use of proxy for x64 wininet, urlmon, and iertutil

### DIFF
--- a/Essentials/iertutil.yml
+++ b/Essentials/iertutil.yml
@@ -15,7 +15,7 @@ Steps:
 - action: cab_extract
   file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
   rename: windows6.1-kb976932-x64.exe
-  url: https://proxy.usebottles.com/redistributable/dependencies/windows6.1-kb976932-x64.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
   file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
   dest: temp/windows6.1-kb976932-x64
 

--- a/Essentials/urlmon.yml
+++ b/Essentials/urlmon.yml
@@ -15,7 +15,7 @@ Steps:
 - action: cab_extract
   file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
   rename: windows6.1-kb976932-x64.exe
-  url: https://proxy.usebottles.com/redistributable/dependencies/windows6.1-kb976932-x64.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
   file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
   dest: temp/windows6.1-kb976932-x64
 

--- a/Essentials/wininet.yml
+++ b/Essentials/wininet.yml
@@ -15,7 +15,7 @@ Steps:
 - action: cab_extract
   file_name: windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
   rename: windows6.1-kb976932-x64.exe
-  url: https://proxy.usebottles.com/redistributable/dependencies/windows6.1-kb976932-x64.exe
+  url: http://download.windowsupdate.com/msdownload/update/software/svpk/2011/02/windows6.1-kb976932-x64_74865ef2562006e51d7f9333b4a8d45b7a749dab.exe
   file_checksum: 28d3932f714bf71d78e75d36aa2e0fb8
   dest: temp/windows6.1-kb976932-x64
 


### PR DESCRIPTION
Fixes #214 

Reverting the use of a proxy for these dependencies because only x86 is available there. 

## Type of change
- [ ] New dependency
- [ ] Manifest fix
- [x] Other

# Was this tested using a [local repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No