### PR TITLE
Add PowerShell

### DIFF
--- a/Essentials/powershell.yml
+++ b/Essentials/powershell.yml
@@ -6,43 +6,25 @@ License_url: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Dependencies:
 - powershell_core
 Steps:
-- action: copy_file
-  file_name: 'null'
-  url: /dev/
-  dest: temp/pswrapper-2.1.1/32/../64/../.null/
-- action: download_archive
-  file_name: powershell32.exe
-  url: https://github.com/ProjectSynchro/powershell-wrapper-for-wine/releases/download/v2.1.1/powershell32.exe
-  rename: pswrapper-2.1.1/32/powershell.exe
-  file_checksum: b2c47af45e741a89621165742998fc1b
-  file_size: 5632
-- action: download_archive
-  file_name: powershell64.exe
-  url: https://github.com/ProjectSynchro/powershell-wrapper-for-wine/releases/download/v2.1.1/powershell64.exe
-  rename: pswrapper-2.1.1/64/powershell.exe
-  file_checksum: c33d1d7cd161494a2de36de637e2d0fb
-  file_size: 6144
-  for:
-    - win64
-- action: download_archive
-  file_name: profile.ps1
-  url: https://github.com/ProjectSynchro/powershell-wrapper-for-wine/releases/download/v2.1.1/profile.ps1
-  rename: pswrapper-2.1.1/profile.ps1
-  file_checksum: d500139b341315546f5f8aea02bc3aab
-  file_size: 6421
+- action: archive_extract
+  file_name: powershell-wrapper.zip
+  url: https://github.com/ProjectSynchro/powershell-wrapper-for-wine/releases/download/v2.1.2/powershell-wrapper.zip
+  rename: pswrapper-2.1.2.zip
+  file_checksum: 0aee3b4f3da961d573766f34d70dc4ef
+  file_size: 8053
 - action: copy_file
   file_name: powershell.exe
-  url: temp/pswrapper-2.1.1/32/
+  url: temp/pswrapper-2.1.2/32/
   dest: win32/WindowsPowerShell/v1.0/
 - action: copy_file
   file_name: powershell.exe
-  url: temp/pswrapper-2.1.1/64/
+  url: temp/pswrapper-2.1.2/64/
   dest: win64/WindowsPowerShell/v1.0/
   for:
     - win64
 - action: copy_file
   file_name: profile.ps1
-  url: temp/pswrapper-2.1.1/
+  url: temp/pswrapper-2.1.2/
   dest: windows/../Program Files/PowerShell/7/
 - action: override_dll
   dll: powershell.exe

--- a/Essentials/powershell.yml
+++ b/Essentials/powershell.yml
@@ -1,0 +1,49 @@
+Name: powershell
+Description: PowerShell Wrapper For Wine
+Provider: ProjectSynchro
+License: GPLv2
+License_url: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+Dependencies:
+- powershell_core
+Steps:
+- action: copy_file
+  file_name: 'null'
+  url: /dev/
+  dest: temp/pswrapper-2.1.1/32/../64/../.null/
+- action: download_archive
+  file_name: powershell32.exe
+  url: https://github.com/ProjectSynchro/powershell-wrapper-for-wine/releases/download/v2.1.1/powershell32.exe
+  rename: pswrapper-2.1.1/32/powershell.exe
+  file_checksum: b2c47af45e741a89621165742998fc1b
+  file_size: 5632
+- action: download_archive
+  file_name: powershell64.exe
+  url: https://github.com/ProjectSynchro/powershell-wrapper-for-wine/releases/download/v2.1.1/powershell64.exe
+  rename: pswrapper-2.1.1/64/powershell.exe
+  file_checksum: c33d1d7cd161494a2de36de637e2d0fb
+  file_size: 6144
+  for:
+    - win64
+- action: download_archive
+  file_name: profile.ps1
+  url: https://github.com/ProjectSynchro/powershell-wrapper-for-wine/releases/download/v2.1.1/profile.ps1
+  rename: pswrapper-2.1.1/profile.ps1
+  file_checksum: d500139b341315546f5f8aea02bc3aab
+  file_size: 6421
+- action: copy_file
+  file_name: powershell.exe
+  url: temp/pswrapper-2.1.1/32/
+  dest: win32/WindowsPowerShell/v1.0/
+- action: copy_file
+  file_name: powershell.exe
+  url: temp/pswrapper-2.1.1/64/
+  dest: win64/WindowsPowerShell/v1.0/
+  for:
+    - win64
+- action: copy_file
+  file_name: profile.ps1
+  url: temp/pswrapper-2.1.1/
+  dest: windows/../Program Files/PowerShell/7/
+- action: override_dll
+  dll: powershell.exe
+  type: native,builtin

--- a/Essentials/powershell_core.yml
+++ b/Essentials/powershell_core.yml
@@ -1,0 +1,25 @@
+Name: powershell_core
+Description: Microsoft PowerShell
+Provider: Microsoft
+License: MIT
+License_url: https://github.com/PowerShell/PowerShell/blob/master/LICENSE.txt
+Dependencies: []
+Steps:
+- action: install_msi
+  file_name: PowerShell-7.2.21-win-x86.msi
+  url: https://github.com/PowerShell/PowerShell/releases/download/v7.2.21/PowerShell-7.2.21-win-x86.msi
+  rename: PowerShell-7.2.21-win-x86.msi
+  file_checksum: ff9106b27dcfbf7d5f153f95356952f8
+  file_size: 96886784
+  arguments: /quiet ENABLE_PSREMOTING=1 REGISTER_MANIFEST=1
+  for:
+    - win32
+- action: install_msi
+  file_name: PowerShell-7.2.21-win-x64.msi
+  url: https://github.com/PowerShell/PowerShell/releases/download/v7.2.21/PowerShell-7.2.21-win-x64.msi
+  rename: PowerShell-7.2.21-win-x64.msi
+  file_checksum: caa2a4cbb2ab995ca5447c442751694c
+  file_size: 105873408
+  arguments: /quiet ENABLE_PSREMOTING=1 REGISTER_MANIFEST=1
+  for:
+    - win64


### PR DESCRIPTION
Related to https://github.com/bottlesdevs/dependencies/issues/126

Some software needs PowerShell to run commands with elevated privileges...

For example... the Star Citizen game launcher, which uses PowerShell to create/verify the game directories/files and self-update. If merged... would no longer be necessary to use [`mkdir` to create the game directories](https://github.com/bottlesdevs/programs/blob/f6b7b18e437f698143873b3f7a56997c1b64ae86/Games/starcitizen.yml#L43), would be sufficient to add `powershell` to the dependencies(like [here](https://github.com/Open-Wine-Components/umu-protonfixes/blob/6e5dd09697e451a6a90a0989f2749fa9a5761ab8/gamefixes-umu/umu-starcitizen.py#L22)).

I made these manifests [based on the verbs that were recently merged into Winetricks](https://github.com/Winetricks/winetricks/pull/2211).

## Type of change
- [x] New dependency
- [ ] Manifest fix
- [ ] Other

# Was this tested using a [local repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
