### PR TITLE
powershell.yml: Bump wrapper version to 2.1.3

### DIFF
--- a/Essentials/powershell.yml
+++ b/Essentials/powershell.yml
@@ -8,23 +8,23 @@ Dependencies:
 Steps:
 - action: archive_extract
   file_name: powershell-wrapper.zip
-  url: https://github.com/ProjectSynchro/powershell-wrapper-for-wine/releases/download/v2.1.2/powershell-wrapper.zip
-  rename: pswrapper-2.1.2.zip
-  file_checksum: 0aee3b4f3da961d573766f34d70dc4ef
-  file_size: 8053
+  url: https://github.com/ProjectSynchro/powershell-wrapper-for-wine/releases/download/v2.1.3/powershell-wrapper.zip
+  rename: pswrapper-2.1.3.zip
+  file_checksum: e60895ea12b80d67cd609446087307ed
+  file_size: 8866
 - action: copy_file
   file_name: powershell.exe
-  url: temp/pswrapper-2.1.2/32/
+  url: temp/pswrapper-2.1.3/32/
   dest: win32/WindowsPowerShell/v1.0/
 - action: copy_file
   file_name: powershell.exe
-  url: temp/pswrapper-2.1.2/64/
+  url: temp/pswrapper-2.1.3/64/
   dest: win64/WindowsPowerShell/v1.0/
   for:
     - win64
 - action: copy_file
   file_name: profile.ps1
-  url: temp/pswrapper-2.1.2/
+  url: temp/pswrapper-2.1.3/
   dest: windows/../Program Files/PowerShell/7/
 - action: override_dll
   dll: powershell.exe


### PR DESCRIPTION
Bumps the wrapper version to 2.1.3

Fixes [ProjectSynchro/powershell-wrapper-for-wine#2](https://github.com/ProjectSynchro/powershell-wrapper-for-wine/issues/2) which fixes installing the EAC service in the RSI Launcher.

## Type of change
- [ ] New dependency
- [x] Manifest fix
- [ ] Other

# Was this tested using a [local repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
