### PR TITLE
Remove build versions from `vcredist` index descriptions

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -31,16 +31,16 @@ vcredist2012:
   Description: Microsoft Visual C++ Redistributable for Visual Studio 2012
   Category: Essentials
 vcredist2013:
-  Description: Microsoft Visual C++ Redistributable (2013) 12.0
+  Description: Microsoft Visual C++ Redistributable (2013)
   Category: Essentials
 vcredist2015:
   Description: Microsoft Visual C++ Redistributable (2015)
   Category: Essentials
 vcredist2019:
-  Description: Microsoft Visual C++ Redistributable (2015-2019) 14.28.29325
+  Description: Microsoft Visual C++ Redistributable (2015-2019)
   Category: Essentials
 vcredist2022:
-  Description: Microsoft Visual C++ Redistributable (2015-2022) 14.38.33135
+  Description: Microsoft Visual C++ Redistributable (2015-2022)
   Category: Essentials
 
 # .NET FRAMEWORKS


### PR DESCRIPTION
Fixes https://github.com/bottlesdevs/dependencies/issues/260.

Keeping the build versions in the manifest descriptions (for bookkeeping and debug).

## Type of change

- [ ] New dependency
- [ ] Manifest fix
- [x] Other

## Was this tested using a [local repository](https://maintainers.usebottles.com/Testing)?

- [x] Yes
- [ ] No

Setup:

```shell
$ bottles --version

51.13

$ export LOCAL_DEPENDENCIES=/path/to/local/git/clone

$ bottles
```

![Fixed vcredist Descriptions](https://github.com/user-attachments/assets/10ab0585-a37c-4c60-ae85-99562925e0db)
