### PR TITLE
Update .NET Core Desktop Runtime 8.0.4 → 8.0.12. Add .NET Core Desktop Runtime 9.0.1 + .NET Framework 4.8.1.

### DIFF
--- a/Essentials/dotnet481.yml
+++ b/Essentials/dotnet481.yml
@@ -1,0 +1,24 @@
+Name: dotnet481
+Description: Microsoft .NET Framework 4.8.1
+Provider: Microsoft
+License: Microsoft EULA
+License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
+Conflicts:
+  - mono
+Steps:
+  - action: uninstall
+    file_name: Wine Mono
+
+  - action: install_exe
+    environment:
+      WINEDLLOVERRIDES: fusion=b
+    file_name: NDP481-x86-x64-AllOS-ENU.exe
+    url: https://download.microsoft.com/download/4/b/2/cd00d4ed-ebdd-49ee-8a33-eabc3d1030e3/NDP481-x86-x64-AllOS-ENU.exe
+    rename: dotnet481.exe
+    file_checksum: ead82f7ab00fc5847c4d7c292f424267
+    file_size: 77688504
+    arguments: /q /norestart
+
+  - action: override_dll
+    dll: mscoree
+    type: native

--- a/Essentials/dotnetcoredesktop8.yml
+++ b/Essentials/dotnetcoredesktop8.yml
@@ -3,22 +3,19 @@ Description: Microsoft .NET Core Desktop Runtime 8.0 LTS
 Provider: Microsoft
 License: Microsoft EULA
 License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
-Dependencies: []
 Steps:
-- action: install_exe
-  file_name: windowsdesktop-runtime-8.0.4-win-x86.exe
-  url: https://download.visualstudio.microsoft.com/download/pr/1fbf5c5f-9770-402d-8971-83da662d8cf9/4e37b3c24bcb6004875b9f8b08024303/windowsdesktop-runtime-8.0.4-win-x86.exe
-  rename: windowsdesktop-runtime-8.0.4-win-x86.exe
-  file_checksum: 462d5e365c384e08539d075d6176b0e5
-  file_size: 53554592
-  arguments: /quiet
-  
-- action: install_exe
-  file_name: windowsdesktop-runtime-8.0.4-win-x64.exe
-  url: https://download.visualstudio.microsoft.com/download/pr/c1d08a81-6e65-4065-b606-ed1127a954d3/14fe55b8a73ebba2b05432b162ab3aa8/windowsdesktop-runtime-8.0.4-win-x64.exe
-  rename: windowsdesktop-runtime-8.0.4-win-x64.exe
-  file_checksum: 4ed51a4f5c761cf37a8841ebb40c5191
-  file_size: 58449920
-  arguments: /quiet
-  for:
-    - win64
+  - action: install_exe
+    file_name: windowsdesktop-runtime-8.0.12-win-x86.exe
+    url: https://download.visualstudio.microsoft.com/download/pr/acf6e5d3-1e2f-4072-833c-fa84a10841c5/acd48342207247f404a5aaa58d1a1ea1/windowsdesktop-runtime-8.0.12-win-x86.exe
+    file_checksum: 8be3c9789f9037fbdb944089eb607b9a
+    file_size: 53873240
+    arguments: /quiet
+
+  - action: install_exe
+    file_name: windowsdesktop-runtime-8.0.12-win-x64.exe
+    url: https://download.visualstudio.microsoft.com/download/pr/f1e7ffc8-c278-4339-b460-517420724524/f36bb75b2e86a52338c4d3a90f8dac9b/windowsdesktop-runtime-8.0.12-win-x64.exe
+    file_checksum: d34739d43f7495e54da045362d9550cb
+    file_size: 58514712
+    arguments: /quiet
+    for:
+      - win64

--- a/Essentials/dotnetcoredesktop9.yml
+++ b/Essentials/dotnetcoredesktop9.yml
@@ -1,0 +1,21 @@
+Name: dotnetcoredesktop9
+Description: Microsoft .NET Core Desktop Runtime 9.0
+Provider: Microsoft
+License: Microsoft EULA
+License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
+Steps:
+  - action: install_exe
+    file_name: windowsdesktop-runtime-9.0.1-win-x86.exe
+    url: https://download.visualstudio.microsoft.com/download/pr/dcd86c7a-9e55-4cc0-8c71-b99ece1350c4/7cc9c0996933075f56ad69c1169e0c1c/windowsdesktop-runtime-9.0.1-win-x86.exe
+    file_checksum: af9d879b0f68d24b05c1c967ca9bc4fb
+    file_size: 55358544
+    arguments: /quiet
+
+  - action: install_exe
+    file_name: windowsdesktop-runtime-9.0.1-win-x64.exe
+    url: https://download.visualstudio.microsoft.com/download/pr/ae0291d4-bcdc-4e56-a952-4f7d84bf2673/1bc4a93f466aab309776931e5a5c4eb4/windowsdesktop-runtime-9.0.1-win-x64.exe
+    file_checksum: e4227cd1a5bd8ef9ce567ff26f2578c6
+    file_size: 60735448
+    arguments: /quiet
+    for:
+      - win64

--- a/index.yml
+++ b/index.yml
@@ -81,6 +81,9 @@ dotnet472:
 dotnet48:
   Description: Microsoft .NET Framework 4.8
   Category: Essentials
+dotnet481:
+  Description: Microsoft .NET Framework 4.8.1
+  Category: Essentials
 dotnetcore3:
   Description: Microsoft .NET Core Runtime 3.1 LTS
   Category: Essentials
@@ -95,6 +98,9 @@ dotnetcoredesktop7:
   Category: Essentials
 dotnetcoredesktop8:
   Description: Microsoft .NET Core Desktop Runtime 8.0 LTS
+  Category: Essentials
+dotnetcoredesktop9:
+  Description: Microsoft .NET Core Desktop Runtime 9.0
   Category: Essentials
 
 # GENERIC


### PR DESCRIPTION
Fixes https://github.com/bottlesdevs/dependencies/issues/266.

Fixes https://github.com/bottlesdevs/dependencies/issues/265.

Fixes https://github.com/bottlesdevs/dependencies/issues/278.

Download links are the resolved redirect download links from Microsoft to pin specific binaries:

* [.NET Framework 4.8.1](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net481) (runtime offline installer)
* [.NET 8.0.12](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
* [.NET 9.0.1](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)

Note that this doesn't fix the issue with the `mscoree.dll` native overrides no longer working for all .NET Framework 4.x versions. That seems to be an issue with Wine or Bottles (https://github.com/bottlesdevs/Bottles/issues/2887), not the dependency manifests. Might be due to missing the Windows Module Installer Service (https://github.com/bottlesdevs/Bottles/issues/3086).

## Type of change

- [x] New dependency
- [ ] Manifest fix
- [ ] Other

## Was this tested using a [local repository](https://maintainers.usebottles.com/Testing)?

- [x] Yes
- [ ] No

Setup:

```shell
$ bottles --version

51.17

$ export PERSONAL_DEPENDENCIES=file:///path/to/local/git/clone

$ bottles
```

<details>
<summary>
<code>dotnet481</code>
</summary>

```text
15:44:21 (INFO) Installing dependency [dotnet481] in bottle [Test].
15:44:21 (INFO) Using Wine Uninstaller -- get_uuid
wineserver: using server-side synchronization.
15:44:22 (INFO) Steam path doesn't exist, creating now.
NDP481-x86-x64-AllOS-ENU.exe (100%) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (74.1MiB/74.1MiB - 51.5MiB)

15:44:23 (INFO) Renaming [NDP481-x86-x64-AllOS-ENU.exe] to [dotnet481.exe].
15:44:23 (INFO) Launching an executable…
wineserver: using server-side synchronization.
0138:err:kerberos:kerberos_LsaApInitializePackage no Kerberos support, expect problems
wine: could not open working directory L"C:\\windows\\sysnative", starting in the Windows directory.
15:44:40 (INFO) Adding Key: [HKEY_CURRENT_USER\Software\Wine\DllOverrides] with Value: [mscoree] and Data: [native] in Test registry
15:44:40 (INFO) Using Wine Registry CLI -- add
wineserver: using server-side synchronization.
15:44:40 (INFO) reg: The operation completed successfully


15:44:40 (INFO) Setting Key Installed_Dependencies=['dotnet481'] for bottle Test…
15:44:40 (INFO) Dependency installed: dotnet481 in Test
```

</details>

<details>
<summary>
<code>dotnetcoredesktop8</code>
</summary>

```text
15:46:14 (INFO) Installing dependency [dotnetcoredesktop8] in bottle [Test].
windowsdesktop-runtime-8.0.11-win-x86.exe (100%) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (51.2MiB/51.2MiB - 48.6MiB)

15:46:15 (INFO) Launching an executable…
wineserver: using server-side synchronization.
windowsdesktop-runtime-8.0.11-win-x64.exe (100%) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (55.8MiB/55.8MiB - 49.3MiB)

15:46:21 (INFO) Launching an executable…
wineserver: using server-side synchronization.
15:46:26 (INFO) Setting Key Installed_Dependencies=['dotnetcoredesktop8'] for bottle Test…
15:46:26 (INFO) Dependency installed: dotnetcoredesktop8 in Test
```

</details>

<details>
<summary>
<code>dotnetcoredesktop9</code>
</summary>

```text
15:46:28 (INFO) Installing dependency [dotnetcoredesktop9] in bottle [Test].
windowsdesktop-runtime-9.0.0-win-x86.exe (100%) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (52.9MiB/52.9MiB - 48.8MiB)

15:46:30 (INFO) Launching an executable…
wineserver: using server-side synchronization.
windowsdesktop-runtime-9.0.0-win-x64.exe (100%) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (57.9MiB/57.9MiB - 50.4MiB)

15:46:36 (INFO) Launching an executable…
wineserver: using server-side synchronization.
15:46:41 (INFO) Setting Key Installed_Dependencies=['dotnetcoredesktop9'] for bottle Test…
15:46:41 (INFO) Dependency installed: dotnetcoredesktop9 in Test
```

</details>