### PR TITLE
Update cnc-ddraw.yml

### DIFF
--- a/Essentials/cnc-ddraw.yml
+++ b/Essentials/cnc-ddraw.yml
@@ -6,15 +6,25 @@ License_url: https://github.com/FunkyFr3sh/cnc-ddraw/blob/master/LICENSE
 Dependencies: []
 Steps:
 - action: archive_extract
-  url: https://github.com/FunkyFr3sh/cnc-ddraw/releases/download/experimental/cnc-ddraw-experimental-debuglog.zip
-  file_name: cnc-ddraw-experimental-debuglog.zip
-  rename: cnc-ddraw.zip
-  file_checksum: 168e560dfc78f94a20f53d08a0d3c8b9
+  url: https://github.com/FunkyFr3sh/cnc-ddraw/releases/download/v7.0.0.0/cnc-ddraw.zip
+  file_name: cnc-ddraw.zip
+  rename: cnc-ddraw-v7.0.0.0.zip
+  file_checksum: ca7381b1202eb4a0b75c5608e67d2e65
 
-- action: copy_dll
+- action: copy_file
   url: temp/cnc-ddraw/
-  file_name: 'ddraw.dll'
+  file_name: '*.*'
   dest: win32
+
+- action: copy_file
+  url: temp/cnc-ddraw/Shaders/
+  file_name: '*.*'
+  dest: win32/Shaders
+
+- action: copy_file
+  url: temp/cnc-ddraw/Shaders/interpolation/
+  file_name: 'catmull-rom-bilinear.glsl'
+  dest: win32/Shaders/interpolation
 
 - action: override_dll
   dll: ddraw

--- a/Essentials/cnc-ddraw.yml
+++ b/Essentials/cnc-ddraw.yml
@@ -6,49 +6,15 @@ License_url: https://github.com/FunkyFr3sh/cnc-ddraw/blob/master/LICENSE
 Dependencies: []
 Steps:
 - action: archive_extract
-  file_name: cnc-ddraw.zip
-  url: https://github.com/FunkyFr3sh/cnc-ddraw/releases/download/v7.0.0.0/cnc-ddraw.zip
-  file_checksum: ca7381b1202eb4a0b75c5608e67d2e65
+  url: https://github.com/FunkyFr3sh/cnc-ddraw/releases/download/experimental/cnc-ddraw-experimental-debuglog.zip
+  file_name: cnc-ddraw-experimental-debuglog.zip
+  rename: cnc-ddraw.zip
+  file_checksum: 168e560dfc78f94a20f53d08a0d3c8b9
 
-- action: copy_file
+- action: copy_dll
   url: temp/cnc-ddraw/
-  file_name: '*'
+  file_name: 'ddraw.dll'
   dest: win32
-
-- action: copy_file
-  url: temp/cnc-ddraw/Shaders/
-  file_name: '*'
-  dest: win32/Shaders
-
-- action: copy_file
-  url: temp/cnc-ddraw/Shaders/crt/
-  file_name: '*'
-  dest: win32/Shaders/crt
-
-- action: copy_file
-  url: temp/cnc-ddraw/Shaders/interpolation/
-  file_name: '*'
-  dest: win32/Shaders/interpolation
-
-- action: copy_file
-  url: temp/cnc-ddraw/Shaders/scanlines/
-  file_name: '*'
-  dest: win32/Shaders/scanlines
-
-- action: copy_file
-  url: temp/cnc-ddraw/Shaders/sharpen/
-  file_name: '*'
-  dest: win32/Shaders/sharpen
-
-- action: copy_file
-  url: temp/cnc-ddraw/Shaders/xbr/
-  file_name: '*'
-  dest: win32/Shaders/xbr
-
-- action: copy_file
-  url: temp/cnc-ddraw/Shaders/xbrz/
-  file_name: '*'
-  dest: win32/Shaders/xbrz
 
 - action: override_dll
   dll: ddraw

--- a/Essentials/cnc-ddraw.yml
+++ b/Essentials/cnc-ddraw.yml
@@ -2,13 +2,13 @@ Name: cnc-ddraw
 Description: Re-implementation of the DirectDraw API for classic games
 Provider: CnCNet
 License: MIT
-License_url: https://github.com/CnCNet/cnc-ddraw/blob/master/LICENSE
+License_url: https://github.com/FunkyFr3sh/cnc-ddraw/blob/master/LICENSE
 Dependencies: []
 Steps:
 - action: archive_extract
   file_name: cnc-ddraw.zip
-  url: https://github.com/CnCNet/cnc-ddraw/releases/download/v4.4.8.0/cnc-ddraw.zip
-  file_checksum: 3e0fa0d3b86ee3d73cf68dc6cdc1aab5
+  url: https://github.com/FunkyFr3sh/cnc-ddraw/releases/download/v7.0.0.0/cnc-ddraw.zip
+  file_checksum: ca7381b1202eb4a0b75c5608e67d2e65
 
 - action: copy_file
   url: temp/cnc-ddraw/

--- a/Essentials/cnc-ddraw.yml
+++ b/Essentials/cnc-ddraw.yml
@@ -1,6 +1,6 @@
 Name: cnc-ddraw
 Description: Re-implementation of the DirectDraw API for classic games
-Provider: CnCNet
+Provider: FunkyFr3sh
 License: MIT
 License_url: https://github.com/FunkyFr3sh/cnc-ddraw/blob/master/LICENSE
 Dependencies: []
@@ -12,72 +12,42 @@ Steps:
 
 - action: copy_file
   url: temp/cnc-ddraw/
-  file_name: '*.exe'
-  dest: win32
-
-- action: copy_file
-  url: temp/cnc-ddraw/
-  file_name: '*.dll'
-  dest: win32
-
-- action: copy_file
-  url: temp/cnc-ddraw/
-  file_name: '*.ini'
+  file_name: '*'
   dest: win32
 
 - action: copy_file
   url: temp/cnc-ddraw/Shaders/
-  file_name: '*.glsl'
-  dest: win32/Shaders
-
-- action: copy_file
-  url: temp/cnc-ddraw/Shaders/
-  file_name: '*.txt'
-  dest: win32/Shaders
-
-- action: copy_file
-  url: temp/cnc-ddraw/Shaders/
-  file_name: '*.zip'
+  file_name: '*'
   dest: win32/Shaders
 
 - action: copy_file
   url: temp/cnc-ddraw/Shaders/crt/
-  file_name: '*.glsl'
+  file_name: '*'
   dest: win32/Shaders/crt
 
 - action: copy_file
-  url: temp/cnc-ddraw/Shaders/cubic/
-  file_name: '*.glsl'
-  dest: win32/Shaders/cubic
-
-- action: copy_file
   url: temp/cnc-ddraw/Shaders/interpolation/
-  file_name: '*.glsl'
+  file_name: '*'
   dest: win32/Shaders/interpolation
 
 - action: copy_file
   url: temp/cnc-ddraw/Shaders/scanlines/
-  file_name: '*.glsl'
+  file_name: '*'
   dest: win32/Shaders/scanlines
 
 - action: copy_file
   url: temp/cnc-ddraw/Shaders/sharpen/
-  file_name: '*.glsl'
+  file_name: '*'
   dest: win32/Shaders/sharpen
 
 - action: copy_file
-  url: temp/cnc-ddraw/Shaders/windowed/
-  file_name: '*.glsl'
-  dest: win32/Shaders/windowed
-
-- action: copy_file
   url: temp/cnc-ddraw/Shaders/xbr/
-  file_name: '*.glsl'
+  file_name: '*'
   dest: win32/Shaders/xbr
 
 - action: copy_file
   url: temp/cnc-ddraw/Shaders/xbrz/
-  file_name: '*.glsl'
+  file_name: '*'
   dest: win32/Shaders/xbrz
 
 - action: override_dll

--- a/Essentials/cnc-ddraw.yml
+++ b/Essentials/cnc-ddraw.yml
@@ -8,7 +8,6 @@ Steps:
 - action: archive_extract
   url: https://github.com/FunkyFr3sh/cnc-ddraw/releases/download/v7.0.0.0/cnc-ddraw.zip
   file_name: cnc-ddraw.zip
-  rename: cnc-ddraw-v7.0.0.0.zip
   file_checksum: ca7381b1202eb4a0b75c5608e67d2e65
 
 - action: copy_file


### PR DESCRIPTION
New repo FunkyFr3sh/cnc-ddraw: previous from CnCNet/cnc-ddraw no longer exists. Updated from v4.4.8.0 to v7.0.0.0

Fixes #289

## Type of change
- [ ] New dependency
- [x] Manifest fix
- [ ] Other

# Was this tested using a [local repository](https://maintainers.usebottles.com/Testing)?
- [ ] Yes
- [x] No
