### PR TITLE
Update Powershell and Powershell Core

### DIFF
--- a/Essentials/powershell.yml
+++ b/Essentials/powershell.yml
@@ -8,23 +8,23 @@ Dependencies:
 Steps:
 - action: archive_extract
   file_name: powershell-wrapper.zip
-  url: https://github.com/ProjectSynchro/powershell-wrapper-for-wine/releases/download/v2.1.3/powershell-wrapper.zip
-  rename: pswrapper-2.1.3.zip
-  file_checksum: e60895ea12b80d67cd609446087307ed
-  file_size: 8866
+  url: https://codeberg.org/Synchro/powershell-wrapper-for-wine/releases/download/v3.0.6/powershell-wrapper.zip
+  rename: pswrapper-3.0.6.zip
+  file_checksum: b6ab606d822ab0ec4f8dc5a7ae63a1f0
+  file_size: 1288912
 - action: copy_file
   file_name: powershell.exe
-  url: temp/pswrapper-2.1.3/32/
+  url: temp/pswrapper-3.0.6/32/
   dest: win32/WindowsPowerShell/v1.0/
 - action: copy_file
   file_name: powershell.exe
-  url: temp/pswrapper-2.1.3/64/
+  url: temp/pswrapper-3.0.6/64/
   dest: win64/WindowsPowerShell/v1.0/
   for:
     - win64
 - action: copy_file
   file_name: profile.ps1
-  url: temp/pswrapper-2.1.3/
+  url: temp/pswrapper-3.0.6/
   dest: windows/../Program Files/PowerShell/7/
 - action: override_dll
   dll: powershell.exe

--- a/Essentials/powershell_core.yml
+++ b/Essentials/powershell_core.yml
@@ -6,20 +6,20 @@ License_url: https://github.com/PowerShell/PowerShell/blob/master/LICENSE.txt
 Dependencies: []
 Steps:
 - action: install_msi
-  file_name: PowerShell-7.2.21-win-x86.msi
-  url: https://github.com/PowerShell/PowerShell/releases/download/v7.2.21/PowerShell-7.2.21-win-x86.msi
-  rename: PowerShell-7.2.21-win-x86.msi
-  file_checksum: ff9106b27dcfbf7d5f153f95356952f8
-  file_size: 96886784
-  arguments: /quiet ENABLE_PSREMOTING=1 REGISTER_MANIFEST=1
+  file_name: PowerShell-7.4.11-win-x86.msi
+  url: https://github.com/PowerShell/PowerShell/releases/download/v7.4.11/PowerShell-7.4.11-win-x86.msi
+  rename: PowerShell-7.4.11-win-x86.msi
+  file_checksum: dbc654619685cb3ea077dc041c65c49c
+  file_size: 102121472
+  arguments: /quiet ENABLE_PSREMOTING=0 REGISTER_MANIFEST=1 DISABLE_TELEMETRY=1 USE_MU=0 ENABLE_MU=0 LAUNCHAPPONEXIT=0
   for:
     - win32
 - action: install_msi
-  file_name: PowerShell-7.2.21-win-x64.msi
-  url: https://github.com/PowerShell/PowerShell/releases/download/v7.2.21/PowerShell-7.2.21-win-x64.msi
-  rename: PowerShell-7.2.21-win-x64.msi
-  file_checksum: caa2a4cbb2ab995ca5447c442751694c
-  file_size: 105873408
-  arguments: /quiet ENABLE_PSREMOTING=1 REGISTER_MANIFEST=1
+  file_name: PowerShell-7.4.11-win-x64.msi
+  url: https://github.com/PowerShell/PowerShell/releases/download/v7.4.11/PowerShell-7.4.11-win-x64.msi
+  rename: PowerShell-7.4.11-win-x64.msi
+  file_checksum: 20c4eafe62d989226b9fe57d2ea045a6
+  file_size: 110043136
+  arguments: /quiet ENABLE_PSREMOTING=0 REGISTER_MANIFEST=1 DISABLE_TELEMETRY=1 USE_MU=0 ENABLE_MU=0 LAUNCHAPPONEXIT=0
   for:
     - win64


### PR DESCRIPTION
Updates Powershell Wrapper to version 3.0.6. The wrapper has been ported to Go, and the repository is now hosted on Codeberg. (https://codeberg.org/Synchro/powershell-wrapper-for-wine)

Updates Powershell Core to v7.4.11. This matches the new installer configuration and version found in Winetricks (https://github.com/Winetricks/winetricks/pull/2355)

## Type of change
- [ ] New dependency
- [x] Manifest fix
- [ ] Other

# Was this tested using a [local repository](https://maintainers.usebottles.com/Testing)?
- [ ] Yes
- [x] No
