### PR TITLE
Update powershell wrapper to version 4.1.0

### DIFF
--- a/Essentials/powershell.yml
+++ b/Essentials/powershell.yml
@@ -8,23 +8,23 @@ Dependencies:
 Steps:
 - action: archive_extract
   file_name: powershell-wrapper.zip
-  url: https://codeberg.org/Synchro/powershell-wrapper-for-wine/releases/download/v3.0.6/powershell-wrapper.zip
-  rename: pswrapper-3.0.6.zip
-  file_checksum: b6ab606d822ab0ec4f8dc5a7ae63a1f0
+  url: https://codeberg.org/Synchro/powershell-wrapper-for-wine/releases/download/v4.1.0/powershell-wrapper.zip
+  rename: pswrapper-4.1.0.zip
+  file_checksum: 4717fc8ad35f57d208d52ba01c6f0ae2
   file_size: 1288912
 - action: copy_file
   file_name: powershell.exe
-  url: temp/pswrapper-3.0.6/32/
+  url: temp/pswrapper-4.1.0/32/
   dest: win32/WindowsPowerShell/v1.0/
 - action: copy_file
   file_name: powershell.exe
-  url: temp/pswrapper-3.0.6/64/
+  url: temp/pswrapper-4.1.0/64/
   dest: win64/WindowsPowerShell/v1.0/
   for:
     - win64
 - action: copy_file
   file_name: profile.ps1
-  url: temp/pswrapper-3.0.6/
+  url: temp/pswrapper-4.1.0/
   dest: windows/../Program Files/PowerShell/7/
 - action: override_dll
   dll: powershell.exe


### PR DESCRIPTION
Updates the powershell wrapper to version 4.1.0.

## Type of change
- [ ] New dependency
- [x] Manifest fix
- [ ] Other

# Was this tested using a [local repository](https://maintainers.usebottles.com/Testing)?
- [x] Yes
- [ ] No
