### PR TITLE
Update VC Redist 2022 to the 14.44.35211

### DIFF
--- a/Essentials/vcredist2022.yml
+++ b/Essentials/vcredist2022.yml
@@ -1,5 +1,5 @@
 Name: vcredist2022
-Description: Microsoft Visual C++ Redistributable (2015-2022) 14.42.34430.0
+Description: Microsoft Visual C++ Redistributable (2015-2022) 14.44.35211
 Provider: Microsoft
 License: Microsoft EULA
 License_url: https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm
@@ -7,18 +7,18 @@ Dependencies: []
 Steps:
   - action: install_exe
     file_name: VC_redist.x86.exe
-    url: https://download.visualstudio.microsoft.com/download/pr/e9ff90f1-424e-4489-9302-28cbaed0fec1/E57FF114114F08F97977887A56975AF754374888E534D87622CEFEB7448653AE/VC_redist.x86.exe
+    url: https://download.visualstudio.microsoft.com/download/pr/7ebf5fdb-36dc-4145-b0a0-90d3d5990a61/0C09F2611660441084CE0DF425C51C11E147E6447963C3690F97E0B25C55ED64/VC_redist.x86.exe
     rename: vcredist2022_x86.exe
-    file_checksum: 822551b098e93c504de2c7865216928f
-    file_size: 13949168
+    file_checksum: 99f52708b06b9c695a8d64a44740bf08
+    file_size: 13953392
     arguments: /quiet /norestart
 
   - action: install_exe
     file_name: VC_redist.x64.exe
-    url: https://download.visualstudio.microsoft.com/download/pr/d0b3ad8b-1c44-414d-bbff-194674212243/8BAA7319CFC0285F1D71FD7A617CC10AB3A736A1FCAF2771EB83A50EF2236002/VC_redist.x64.exe
+    url: https://download.visualstudio.microsoft.com/download/pr/7ebf5fdb-36dc-4145-b0a0-90d3d5990a61/CC0FF0EB1DC3F5188AE6300FAEF32BF5BEEBA4BDD6E8E445A9184072096B713B/VC_redist.x64.exe
     rename: vcredist2022_x64.exe
-    file_checksum: 52f4f5a6adc24bce21dbceac2e2ad809
-    file_size: 25641080
+    file_checksum: 486f81facf798678c3244c7cf35a557f
+    file_size: 25635768
     arguments: /quiet /norestart
     for:
       - win64


### PR DESCRIPTION
Current latest version for the 2022 is a bit old. Updated to the latest. Note that this is not 2026 version but 2022 just as how it was used before.

## Type of change
- [ ] New dependency
- [X] Manifest fix
- [ ] Other

# Was this tested using a [local repository](https://maintainers.usebottles.com/Testing)?
- [X] Yes
- [ ] No
