### PR TITLE
fix: correct VC++ 2008 overrides

### DIFF
--- a/Essentials/vcredist2008.yml
+++ b/Essentials/vcredist2008.yml
@@ -24,21 +24,21 @@ Steps:
     - win64
 
 - action: override_dll
-  dll: atl80
+  dll: atl90
   type: native,builtin
 
 - action: override_dll
-  dll: msvcm80
+  dll: msvcm90
   type: native,builtin
 
 - action: override_dll
-  dll: msvcp80
+  dll: msvcp90
   type: native,builtin
 
 - action: override_dll
-  dll: msvcr80
+  dll: msvcr90
   type: native,builtin
-  
+
 - action: override_dll
-  dll: vcomp
+  dll: vcomp90
   type: native,builtin


### PR DESCRIPTION
Closes bottlesdevs/Bottles#4805

## Type of change
- [ ] New dependency
- [x] Manifest fix
- [ ] Other

# Was this tested using a [local repository](https://maintainers.usebottles.com/Testing)?
- [ ] Yes
- [x] No

The manifest parses successfully and now matches the VC++ 2008 DLL set used by Winetricks.